### PR TITLE
feat/expanding-file-system-operations

### DIFF
--- a/src/openstaad_mcp/sandbox/com_proxy.py
+++ b/src/openstaad_mcp/sandbox/com_proxy.py
@@ -2,28 +2,149 @@
 COM object proxy for the sandbox.
 
 Wraps pywin32 CDispatch objects to block access to internal attributes
-(_oleobj_, _ApplyTypes_, etc.) and dangerous methods that accept file paths.
+(_oleobj_, _ApplyTypes_, etc.) and validates file-path arguments on
+methods that interact with the filesystem.
 """
 
 from __future__ import annotations
 
+import os
 import re
+from dataclasses import dataclass
 from typing import Any
 
-# COM methods that accept filesystem paths and must be blocked.
-# These can write files, open UNC paths (NTLM relay), or modify the model file.
-BLOCKED_COM_METHODS: frozenset[str] = frozenset(
-    {
-        "NewSTAADFile",
-        "OpenSTAADFile",
-        "SaveAs",
-        "CloseSTAADFile",
-        "ExportView",
-    }
+# UNC path patterns for detecting NTLM relay attempts in any string argument.
+# Covers: \\server\share  //server/share  \\?\UNC\server\share
+_UNC_RE = re.compile(r"^(?:\\\\|//|\\\\\?\\UNC\\)", re.ASCII | re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Path-validation infrastructure
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PathRule:
+    """Declares which positional arg carries a file path and what extensions are legal."""
+
+    arg_index: int
+    allowed_extensions: frozenset[str]
+
+    def validate(self, args: tuple[Any, ...], method_name: str) -> None:
+        """Extract the path from *args* and run :func:`validate_file_path`."""
+        if self.arg_index >= len(args):
+            raise ValueError(f"'{method_name}' requires a file path as positional argument {self.arg_index}")
+        validate_file_path(args[self.arg_index], allowed_extensions=self.allowed_extensions, method_name=method_name)
+
+
+@dataclass(frozen=True)
+class _CompositePathRule:
+    """Rule for methods where the path is split across two arguments (directory + filename).
+
+    The validator joins ``args[dir_arg_index] / args[name_arg_index]`` into a
+    single path before running :func:`validate_file_path`.
+    """
+
+    dir_arg_index: int
+    name_arg_index: int
+    allowed_extensions: frozenset[str]
+
+    def validate(self, args: tuple[Any, ...], method_name: str) -> None:
+        """Join directory + filename from *args* and run :func:`validate_file_path`."""
+        if self.dir_arg_index >= len(args) or self.name_arg_index >= len(args):
+            raise ValueError(
+                f"'{method_name}' requires a directory (arg {self.dir_arg_index}) "
+                f"and a filename (arg {self.name_arg_index})"
+            )
+        dir_part = args[self.dir_arg_index]
+        name_part = args[self.name_arg_index]
+        if not isinstance(dir_part, str) or not isinstance(name_part, str):
+            raise ValueError(f"'{method_name}' requires string arguments for directory and filename")
+        validate_file_path(
+            os.path.join(dir_part, name_part),
+            allowed_extensions=self.allowed_extensions,
+            method_name=method_name,
+        )
+
+
+# COM methods that accept a filesystem path and must be validated before the
+# call is forwarded.  Each entry maps the method name to a rule that describes
+# where the path lives and which file extensions are acceptable.
+VALIDATED_COM_METHODS: dict[str, _PathRule | _CompositePathRule] = {
+    "NewSTAADFile": _PathRule(arg_index=0, allowed_extensions=frozenset({".std"})),
+    "OpenSTAADFile": _PathRule(arg_index=0, allowed_extensions=frozenset({".std"})),
+    "SaveAs": _PathRule(arg_index=0, allowed_extensions=frozenset({".std"})),
+    "ExportView": _CompositePathRule(
+        dir_arg_index=0,
+        name_arg_index=1,
+        allowed_extensions=frozenset({".png", ".jpg", ".jpeg", ".bmp", ".emf", ".wmf"}),
+    ),
+}
+
+# Normalised directory prefixes (after os.path.splitdrive, lower-cased) that
+# must never be written to or read from.
+_PROTECTED_DIR_PREFIXES: tuple[str, ...] = (
+    os.sep + "windows" + os.sep,
+    os.sep + "program files" + os.sep,
+    os.sep + "program files (x86)" + os.sep,
+    os.sep + "programdata" + os.sep,
+    os.sep + "system volume information" + os.sep,
+    os.sep + "$recycle.bin" + os.sep,
 )
 
-# UNC path pattern for detecting NTLM relay attempts in any string argument
-_UNC_RE = re.compile(r"^\\\\", re.ASCII)
+
+def validate_file_path(
+    path: str,
+    *,
+    allowed_extensions: frozenset[str],
+    method_name: str,
+) -> None:
+    """Raise :class:`ValueError` if *path* is unsafe for a COM file operation.
+
+    Checks performed (in order):
+    1. Must be a non-empty string.
+    2. Must not be a UNC path (``\\\\...``).
+    3. Must be absolute (has a drive letter on Windows).
+    4. Must not contain ``..`` segments (path traversal).
+    5. Must end with one of the *allowed_extensions*.
+    6. Must not target a protected OS directory.
+    """
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError(f"'{method_name}' requires a non-empty file path string")
+
+    if "\x00" in path:
+        raise ValueError(f"Null bytes are not allowed in file paths (blocked in '{method_name}')")
+
+    if _UNC_RE.match(path):
+        raise ValueError(f"UNC paths are not allowed (blocked in '{method_name}')")
+
+    # Reject path-traversal sequences in the raw input *before* normalisation,
+    # so tricks like "C:\models\..\..\Windows\file.std" are caught immediately.
+    if ".." in path.replace("/", os.sep).split(os.sep):
+        raise ValueError(f"Path traversal ('..') is not allowed in '{method_name}'")
+
+    # Normalise early so we can reliably check extension and directory.
+    try:
+        normalized = os.path.normpath(path)
+    except (ValueError, OSError) as exc:
+        raise ValueError(f"Invalid path passed to '{method_name}': {exc}") from None
+
+    # Must be absolute (drive letter on Windows).
+    if not os.path.isabs(normalized):
+        raise ValueError(f"'{method_name}' requires an absolute file path, got relative path")
+
+    # Extension check.
+    _, ext = os.path.splitext(normalized)
+    if ext.lower() not in allowed_extensions:
+        allowed = ", ".join(sorted(allowed_extensions))
+        raise ValueError(f"'{method_name}' only allows files with extensions: {allowed}; got '{ext}'")
+
+    # Protected-directory check.
+    _, tail = os.path.splitdrive(normalized.lower())
+    tail_with_sep = tail if tail.endswith(os.sep) else tail + os.sep
+    for prefix in _PROTECTED_DIR_PREFIXES:
+        if tail_with_sep.startswith(prefix):
+            raise ValueError(f"'{method_name}' cannot access files in a protected system directory")
 
 
 class COMProxy:
@@ -50,9 +171,6 @@ class COMProxy:
         # Block pywin32 internal attributes (single underscore prefix)
         if name.startswith("_"):
             raise AttributeError(f"access to '{name}' is not allowed on COM objects in the sandbox")
-        # Block dangerous COM methods
-        if name in BLOCKED_COM_METHODS:
-            raise AttributeError(f"'{name}' is not allowed in the sandbox (filesystem operation)")
 
         obj = object.__getattribute__(self, "_com_obj")
         value = getattr(obj, name)
@@ -64,6 +182,9 @@ class COMProxy:
 
         # Wrap callable results to intercept path arguments
         if callable(value):
+            rule = VALIDATED_COM_METHODS.get(name)
+            if rule is not None:
+                return _ValidatedFileMethodWrapper(value, name, rule)
             return _SafeMethodWrapper(value, name)
 
         return value
@@ -104,6 +225,45 @@ class _SafeMethodWrapper:
     def __repr__(self) -> str:
         name = object.__getattribute__(self, "_name")
         return f"<sandbox COM method '{name}'>"
+
+
+class _ValidatedFileMethodWrapper:
+    """Wraps a COM method that accepts a filesystem path.
+
+    Runs :func:`validate_file_path` on the designated positional argument
+    before forwarding the call, in addition to the standard UNC-path check
+    on all string arguments.
+    """
+
+    __slots__ = ("_method", "_name", "_rule")
+
+    def __init__(self, method: Any, name: str, rule: _PathRule | _CompositePathRule) -> None:
+        object.__setattr__(self, "_method", method)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_rule", rule)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        name = object.__getattribute__(self, "_name")
+        rule: _PathRule | _CompositePathRule = object.__getattribute__(self, "_rule")
+
+        # --- UNC check on every string argument (same as _SafeMethodWrapper) ---
+        for arg in args:
+            if isinstance(arg, str) and _UNC_RE.match(arg):
+                raise ValueError(f"UNC paths are not allowed in COM method calls (blocked in '{name}')")
+        for val in kwargs.values():
+            if isinstance(val, str) and _UNC_RE.match(val):
+                raise ValueError(f"UNC paths are not allowed in COM method calls (blocked in '{name}')")
+
+        # --- Validate the designated path argument(s) ---
+        rule.validate(args, name)
+
+        method = object.__getattribute__(self, "_method")
+        result = method(*args, **kwargs)
+        return _maybe_wrap(result)
+
+    def __repr__(self) -> str:
+        name = object.__getattribute__(self, "_name")
+        return f"<sandbox validated COM method '{name}'>"
 
 
 def _maybe_wrap(value: Any) -> Any:

--- a/src/openstaad_mcp/staad_skills/staad-core/SKILL.md
+++ b/src/openstaad_mcp/staad_skills/staad-core/SKILL.md
@@ -73,6 +73,37 @@ Always work on the **currently open model**. If the user says "create a model", 
 - Use `staad.GetSTAADFile()` to get the current model path
 - `staad.GetSTAADFileFolder()` returns the folder path
 
+#### Opening, Creating & Saving Files
+
+The following functions are available but **path-validated** by the sandbox:
+
+- `staad.OpenSTAADFile(filePath)` — open an existing STAAD model file
+- `staad.NewSTAADFile(filePath, envCode, unitCode)` — create a new STAAD model file
+- `staad.SaveAs(filePath)` — save the current model to a new file path
+- `staad.CloseSTAADFile()` — close the currently open model
+
+**Path rules** (enforced automatically — violations raise an error):
+
+- The path **must be absolute** (e.g. `"C:\\Users\\me\\models\\bridge.std"`)
+- The file **must end with `.std`**
+- UNC paths (`\\\\server\\share\\...`) are **blocked**
+- Paths targeting protected OS directories (`Windows`, `Program Files`, `ProgramData`) are **blocked**
+- Path traversal (`..`) is **blocked**
+
+```python
+# Open an existing model
+staad.OpenSTAADFile("C:\\Projects\\Bridge\\bridge_v2.std")
+
+# Create a new model (envCode=1 for general, unitCode depends on unit system)
+staad.NewSTAADFile("C:\\Projects\\NewModel\\frame.std", 1, 0)
+
+# Save a copy
+staad.SaveAs("C:\\Projects\\Bridge\\bridge_backup.std")
+
+# Close the current model
+staad.CloseSTAADFile()
+```
+
 ### Application Control
 
 - `staad.ShowApplication()` — show the STAAD.Pro window

--- a/src/openstaad_mcp/staad_skills/staad-core/assets/FUNCTION_SKILL_MAP.md
+++ b/src/openstaad_mcp/staad_skills/staad-core/assets/FUNCTION_SKILL_MAP.md
@@ -7,217 +7,222 @@ Load the governing skill via `read_skills(["skill-name"])` before writing any sc
 
 ## openstaadroot → staad-core
 
-| Function | Purpose |
-|---|---|
-| `GetSTAADFile` / `GetSTAADFileFolder` | Returns path of open model |
-| `GetBaseUnit` / `GetInputUnitForLength` / `GetInputUnitForForce` | Unit queries |
-| `SetInputUnits` / `SetInputUnitForLength` / `SetInputUnitForForce` | Unit assignment — see UNIT_CODES.md |
-| `SaveModel` | Save current model — REQUIRE EXPLICIT USER INTENT |
-| `SetSilentMode` | Suppress UI dialogs before mutating ops |
-| `UpdateStructure` | **Reload from disk** — discards in-memory geometry; use `SaveModel(True)` instead |
-| `AnalyzeModel` / `AnalyzeEx` | Run analysis (`AnalyzeEx` preferred — returns status code) |
-| `GetAnalysisStatus` / `IsAnalyzing` | Analysis state queries |
-| `GetApplicationVersion` / `ShowApplication` / `Quit` | Application control |
-| `IsPhysicalModel` | Model type query |
-| `GetFullJobInfo` / `GetShortJobInfo` / `SetFullJobInfo` / `SetShortJobInfo` | Job metadata |
-| `GetMainWindowHandle` / `GetProcessHandle` / `GetProcessId` | Process handles |
+| Function                                                                    | Purpose                                                                           |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `GetSTAADFile` / `GetSTAADFileFolder`                                       | Returns path of open model                                                        |
+| `GetBaseUnit` / `GetInputUnitForLength` / `GetInputUnitForForce`            | Unit queries                                                                      |
+| `SetInputUnits` / `SetInputUnitForLength` / `SetInputUnitForForce`          | Unit assignment — see UNIT_CODES.md                                               |
+| `SaveModel`                                                                 | Save current model — REQUIRE EXPLICIT USER INTENT                                 |
+| `NewSTAADFile`                                                              | Create new model file (`.std` path required, path-validated)                      |
+| `OpenSTAADFile`                                                             | Open existing model file (`.std` path required, path-validated)                   |
+| `SaveAs`                                                                    | Save model to new path (`.std` path required, path-validated)                     |
+| `CloseSTAADFile`                                                            | Close current model                                                               |
+| `SetSilentMode`                                                             | Suppress UI dialogs before mutating ops                                           |
+| `UpdateStructure`                                                           | **Reload from disk** — discards in-memory geometry; use `SaveModel(True)` instead |
+| `AnalyzeModel` / `AnalyzeEx`                                                | Run analysis (`AnalyzeEx` preferred — returns status code)                        |
+| `GetAnalysisStatus` / `IsAnalyzing`                                         | Analysis state queries                                                            |
+| `GetApplicationVersion` / `ShowApplication` / `Quit`                        | Application control                                                               |
+| `IsPhysicalModel`                                                           | Model type query                                                                  |
+| `GetFullJobInfo` / `GetShortJobInfo` / `SetFullJobInfo` / `SetShortJobInfo` | Job metadata                                                                      |
+| `GetMainWindowHandle` / `GetProcessHandle` / `GetProcessId`                 | Process handles                                                                   |
 
 ---
 
 ## osgeometry → staad-geometry
 
-| Function | Purpose |
-|---|---|
-| `AddNode` / `AddBeam` / `AddPlate` / `AddSolid` | Create single elements |
-| `AddMultipleNodes` / `AddMultipleBeams` / `AddMultiplePlates` | Bulk element creation |
-| `CreateNode` / `CreateBeam` / `CreatePlate` / `CreateSolid` | Create with explicit IDs |
-| `GetNodeList` / `GetBeamList` / `GetPlateList` / `GetSolidList` | List all IDs |
-| `GetNodeCount` / `GetMemberCount` / `GetPlateCount` / `GetSolidCount` | Element counts |
-| `GetNodeCoordinates` / `SetNodeCoordinate` | Node position |
-| `GetMemberIncidence` / `GetPlateIncidence` | Connectivity |
-| `GetBeamLength` / `GetNodeDistance` | Distance queries |
-| `GetLastNodeNo` / `GetLastBeamNo` | Highest ID queries |
-| `IsColumn` / `IsBeam` / `IsOrphanNode` | Geometry tests |
-| `DeleteNode` / `DeleteBeam` / `DeletePlate` / `DeleteSolid` | Remove elements |
-| `MergeNodes` / `MergeBeams` | Merge operations |
-| `SplitBeamInEqlParts` / `SplitBeam` | Split beam |
-| `IntersectBeams` / `BreakBeamsAtSpecificNodes` | Intersection/break |
-| `RenumberBeam` | Renumber |
-| `SelectBeam` / `SelectMultipleBeams` / `ClearMemberSelection` | Beam selection |
-| `SelectNode` / `SelectMultipleNodes` / `ClearNodeSelection` | Node selection |
-| `SelectPlate` / `SelectMultiplePlates` / `ClearPlateSelection` | Plate selection |
-| `SelectSolid` / `SelectMultipleSolids` / `ClearSolidSelection` | Solid selection |
-| `GetSelectedBeams` / `GetSelectedNodes` / `GetSelectedPlates` / `GetNoOfSelectedBeams` | Selection query |
-| `CreateGroup` / `CreateGroupEx` / `UpdateGroup` / `DeleteGroup` | Group management |
-| `GetGroupCount` / `GetGroupNames` / `GetGroupEntities` | Group queries |
-| `DoTranslationalRepeat` | Geometry copy/repeat |
-| `DefineParametricSurface` / `AddParametricSurfaceToModel` | Mesh surfaces |
-| `CreatePhysicalMember` / `GetPhysicalMemberCount` | Physical members |
-| `IsZUp` | Vertical axis query |
-| `SetNodeUniqueID` / `GetNodeUniqueID` / `SetMemberUniqueID` / `GetMemberUniqueID` | External IDs |
+| Function                                                                               | Purpose                  |
+| -------------------------------------------------------------------------------------- | ------------------------ |
+| `AddNode` / `AddBeam` / `AddPlate` / `AddSolid`                                        | Create single elements   |
+| `AddMultipleNodes` / `AddMultipleBeams` / `AddMultiplePlates`                          | Bulk element creation    |
+| `CreateNode` / `CreateBeam` / `CreatePlate` / `CreateSolid`                            | Create with explicit IDs |
+| `GetNodeList` / `GetBeamList` / `GetPlateList` / `GetSolidList`                        | List all IDs             |
+| `GetNodeCount` / `GetMemberCount` / `GetPlateCount` / `GetSolidCount`                  | Element counts           |
+| `GetNodeCoordinates` / `SetNodeCoordinate`                                             | Node position            |
+| `GetMemberIncidence` / `GetPlateIncidence`                                             | Connectivity             |
+| `GetBeamLength` / `GetNodeDistance`                                                    | Distance queries         |
+| `GetLastNodeNo` / `GetLastBeamNo`                                                      | Highest ID queries       |
+| `IsColumn` / `IsBeam` / `IsOrphanNode`                                                 | Geometry tests           |
+| `DeleteNode` / `DeleteBeam` / `DeletePlate` / `DeleteSolid`                            | Remove elements          |
+| `MergeNodes` / `MergeBeams`                                                            | Merge operations         |
+| `SplitBeamInEqlParts` / `SplitBeam`                                                    | Split beam               |
+| `IntersectBeams` / `BreakBeamsAtSpecificNodes`                                         | Intersection/break       |
+| `RenumberBeam`                                                                         | Renumber                 |
+| `SelectBeam` / `SelectMultipleBeams` / `ClearMemberSelection`                          | Beam selection           |
+| `SelectNode` / `SelectMultipleNodes` / `ClearNodeSelection`                            | Node selection           |
+| `SelectPlate` / `SelectMultiplePlates` / `ClearPlateSelection`                         | Plate selection          |
+| `SelectSolid` / `SelectMultipleSolids` / `ClearSolidSelection`                         | Solid selection          |
+| `GetSelectedBeams` / `GetSelectedNodes` / `GetSelectedPlates` / `GetNoOfSelectedBeams` | Selection query          |
+| `CreateGroup` / `CreateGroupEx` / `UpdateGroup` / `DeleteGroup`                        | Group management         |
+| `GetGroupCount` / `GetGroupNames` / `GetGroupEntities`                                 | Group queries            |
+| `DoTranslationalRepeat`                                                                | Geometry copy/repeat     |
+| `DefineParametricSurface` / `AddParametricSurfaceToModel`                              | Mesh surfaces            |
+| `CreatePhysicalMember` / `GetPhysicalMemberCount`                                      | Physical members         |
+| `IsZUp`                                                                                | Vertical axis query      |
+| `SetNodeUniqueID` / `GetNodeUniqueID` / `SetMemberUniqueID` / `GetMemberUniqueID`      | External IDs             |
 
 ---
 
 ## osload → staad-loading
 
-| Function | Purpose |
-|---|---|
-| `CreateNewPrimaryLoad` / `CreateNewPrimaryLoadEx` / `CreateNewPrimaryLoadEx2` | Create load cases |
-| `CreateNewReferenceLoad` | Create reference load case |
-| `CreateNewLoadCombination` | Create combination case |
-| `SetLoadActive` / `SetReferenceLoadActive` | Activate case for editing |
-| `SetLoadType` | Assign load category — see LOAD_CODES.md |
-| `AddSelfWeightInXYZ` / `AddSelfWeightInXYZToGeometry` | Self-weight |
-| `AddNodalLoad` | Joint forces/moments |
-| `AddSupportDisplacement` | Prescribed support displacement |
-| `AddMemberUniformForce` / `AddMemberUniformMoment` | UDL |
-| `AddMemberConcForce` / `AddMemberConcMoment` | Concentrated loads |
-| `AddMemberTrapezoidal` / `AddMemberLinearVari` | Variable member loads |
-| `AddMemberAreaLoad` / `AddMemberFloorLoad` / `AddMemberFloorLoadEx` | Floor/area loads |
-| `AddMemberFixedEnd` / `AddStrainLoad` / `AddTemperatureLoad` | Misc member loads |
-| `AddElementPressure` / `AddElementTrapPressureEx` / `AddElementHydrostaticPressure` | Plate loads |
-| `AddWindDefinition` / `AddWindIntensity` / `AddWindExposure` / `AddWindLoad` | Wind loading |
-| `AddSeismicDefinition` / `AddSeismicDefSelfWeight` / `AddSeismicLoad` | Seismic loading |
-| `AddLoadAndFactorToCombination` / `AddAutoLoadCombinations` | Combination factors |
-| `AddRepeatLoad` / `AddReferenceLoad` | Repeat/reference loads |
-| `CreateLoadEnvelop` / `AddLoadCasesToEnvelop` / `DeleteLoadEnvelop` | Load envelopes |
-| `GetPrimaryLoadCaseNumbers` / `GetPrimaryLoadCaseCount` | Load case queries |
-| `GetLoadCombinationCaseNumbers` / `GetLoadCombinationCaseCount` | Combination queries |
-| `GetLoadCaseTitle` / `GetLoadType` / `GetActiveLoad` | Load metadata |
-| `GetNodalLoads` / `GetUDLLoads` / `GetConcForces` / `GetTrapLoads` | Load read queries |
-| `IsCombinationCase` / `IsDynamicLoadIncluded` | Type checks |
-| `ClearPrimaryLoadCase` / `DeletePrimaryLoadCases` / `DeleteReferenceLoadCases` | Delete/clear |
-| `GetAssignmentListForLoadType` / `GetListSizeForLoadType` | Assignment queries |
+| Function                                                                            | Purpose                                  |
+| ----------------------------------------------------------------------------------- | ---------------------------------------- |
+| `CreateNewPrimaryLoad` / `CreateNewPrimaryLoadEx` / `CreateNewPrimaryLoadEx2`       | Create load cases                        |
+| `CreateNewReferenceLoad`                                                            | Create reference load case               |
+| `CreateNewLoadCombination`                                                          | Create combination case                  |
+| `SetLoadActive` / `SetReferenceLoadActive`                                          | Activate case for editing                |
+| `SetLoadType`                                                                       | Assign load category — see LOAD_CODES.md |
+| `AddSelfWeightInXYZ` / `AddSelfWeightInXYZToGeometry`                               | Self-weight                              |
+| `AddNodalLoad`                                                                      | Joint forces/moments                     |
+| `AddSupportDisplacement`                                                            | Prescribed support displacement          |
+| `AddMemberUniformForce` / `AddMemberUniformMoment`                                  | UDL                                      |
+| `AddMemberConcForce` / `AddMemberConcMoment`                                        | Concentrated loads                       |
+| `AddMemberTrapezoidal` / `AddMemberLinearVari`                                      | Variable member loads                    |
+| `AddMemberAreaLoad` / `AddMemberFloorLoad` / `AddMemberFloorLoadEx`                 | Floor/area loads                         |
+| `AddMemberFixedEnd` / `AddStrainLoad` / `AddTemperatureLoad`                        | Misc member loads                        |
+| `AddElementPressure` / `AddElementTrapPressureEx` / `AddElementHydrostaticPressure` | Plate loads                              |
+| `AddWindDefinition` / `AddWindIntensity` / `AddWindExposure` / `AddWindLoad`        | Wind loading                             |
+| `AddSeismicDefinition` / `AddSeismicDefSelfWeight` / `AddSeismicLoad`               | Seismic loading                          |
+| `AddLoadAndFactorToCombination` / `AddAutoLoadCombinations`                         | Combination factors                      |
+| `AddRepeatLoad` / `AddReferenceLoad`                                                | Repeat/reference loads                   |
+| `CreateLoadEnvelop` / `AddLoadCasesToEnvelop` / `DeleteLoadEnvelop`                 | Load envelopes                           |
+| `GetPrimaryLoadCaseNumbers` / `GetPrimaryLoadCaseCount`                             | Load case queries                        |
+| `GetLoadCombinationCaseNumbers` / `GetLoadCombinationCaseCount`                     | Combination queries                      |
+| `GetLoadCaseTitle` / `GetLoadType` / `GetActiveLoad`                                | Load metadata                            |
+| `GetNodalLoads` / `GetUDLLoads` / `GetConcForces` / `GetTrapLoads`                  | Load read queries                        |
+| `IsCombinationCase` / `IsDynamicLoadIncluded`                                       | Type checks                              |
+| `ClearPrimaryLoadCase` / `DeletePrimaryLoadCases` / `DeleteReferenceLoadCases`      | Delete/clear                             |
+| `GetAssignmentListForLoadType` / `GetListSizeForLoadType`                           | Assignment queries                       |
 
 ---
 
 ## osproperty → staad-properties
 
-| Function | Purpose |
-|---|---|
-| `CreateBeamPropertyFromTable` / `CreateBeamPropertyFromTableEx` | Section from DB — see PROPERTY_CODES.md |
-| `CreateAnglePropertyFromTable` / `CreateChannelPropertyFromTable` / `CreateTeePropertyFromTable` | Shape-specific sections |
-| `CreateTubePropertyFromTable` / `CreatePipePropertyFromTable` | Hollow sections |
-| `CreateWideFlangePropertyFromTable` | Wide flange |
-| `CreatePrismaticRectangleProperty` / `CreatePrismaticCircleProperty` / `CreatePrismaticTeeProperty` | Prismatic shapes |
-| `CreatePrismaticGeneralProperty` / `CreateTaperedIProperty` / `CreateTaperedTubeProperty` | Advanced prismatic |
-| `CreatePlateThicknessProperty` | Plate thickness |
-| `AssignBeamProperty` / `AssignPlateThickness` | Assign section/thickness |
-| `AssignBetaAngle` / `GetBetaAngle` | Beta angle |
-| `CreateIsotropicMaterialProperties` / `CreateIsotropicMaterialSteel` / `CreateIsotropicMaterialConcrete` | Material creation |
-| `AssignMaterialToMember` / `AssignMaterialToPlate` / `AssignMaterialToSolid` | Material assignment |
-| `CreateMemberReleaseSpec` / `CreateMemberPartialReleaseSpec` / `DeleteMemberReleaseSpec` | Releases |
-| `CreateMemberTrussSpec` / `CreateMemberTensionSpec` / `CreateMemberCompressionSpec` | Member specs |
-| `CreateMemberCableSpec` / `CreateMemberOffsetSpec` / `CreateMemberFireProofingSpec` | More specs |
-| `AssignMemberSpecToBeam` / `AssignElementSpecToPlate` | Assign specs |
-| `GetBeamProperty` / `GetBeamPropertyAll` / `GetBeamSectionName` | Section queries |
-| `GetSectionPropertyList` / `GetSectionPropertyCount` | Property inventory |
-| `GetPlateThickness` / `GetMaterialProperty` | Read assigned properties |
-| `GetPublishedProfileName` / `GetSTAADProfileName` / `GetRecordForSection` / `GetShapeCode` | DB lookup |
+| Function                                                                                                 | Purpose                                 |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `CreateBeamPropertyFromTable` / `CreateBeamPropertyFromTableEx`                                          | Section from DB — see PROPERTY_CODES.md |
+| `CreateAnglePropertyFromTable` / `CreateChannelPropertyFromTable` / `CreateTeePropertyFromTable`         | Shape-specific sections                 |
+| `CreateTubePropertyFromTable` / `CreatePipePropertyFromTable`                                            | Hollow sections                         |
+| `CreateWideFlangePropertyFromTable`                                                                      | Wide flange                             |
+| `CreatePrismaticRectangleProperty` / `CreatePrismaticCircleProperty` / `CreatePrismaticTeeProperty`      | Prismatic shapes                        |
+| `CreatePrismaticGeneralProperty` / `CreateTaperedIProperty` / `CreateTaperedTubeProperty`                | Advanced prismatic                      |
+| `CreatePlateThicknessProperty`                                                                           | Plate thickness                         |
+| `AssignBeamProperty` / `AssignPlateThickness`                                                            | Assign section/thickness                |
+| `AssignBetaAngle` / `GetBetaAngle`                                                                       | Beta angle                              |
+| `CreateIsotropicMaterialProperties` / `CreateIsotropicMaterialSteel` / `CreateIsotropicMaterialConcrete` | Material creation                       |
+| `AssignMaterialToMember` / `AssignMaterialToPlate` / `AssignMaterialToSolid`                             | Material assignment                     |
+| `CreateMemberReleaseSpec` / `CreateMemberPartialReleaseSpec` / `DeleteMemberReleaseSpec`                 | Releases                                |
+| `CreateMemberTrussSpec` / `CreateMemberTensionSpec` / `CreateMemberCompressionSpec`                      | Member specs                            |
+| `CreateMemberCableSpec` / `CreateMemberOffsetSpec` / `CreateMemberFireProofingSpec`                      | More specs                              |
+| `AssignMemberSpecToBeam` / `AssignElementSpecToPlate`                                                    | Assign specs                            |
+| `GetBeamProperty` / `GetBeamPropertyAll` / `GetBeamSectionName`                                          | Section queries                         |
+| `GetSectionPropertyList` / `GetSectionPropertyCount`                                                     | Property inventory                      |
+| `GetPlateThickness` / `GetMaterialProperty`                                                              | Read assigned properties                |
+| `GetPublishedProfileName` / `GetSTAADProfileName` / `GetRecordForSection` / `GetShapeCode`               | DB lookup                               |
 
 ---
 
 ## ossupport → staad-supports
 
-| Function | Purpose |
-|---|---|
-| `CreateSupportFixed` / `CreateSupportPinned` / `CreateSupportFixedBut` | Create support types |
-| `CreateElasticFooting` / `CreateElasticMat` / `CreatePlateMat` / `CreateInclinedSupport` | Special supports |
-| `AssignSupportToNode` / `AssignSupportToEntityList` | Assign support |
-| `RemoveSupportFromNode` / `DeleteSupport` | Remove support |
-| `GetSupportCount` / `GetSupportNodes` / `GetSupportType` | Support queries |
-| `GetSupportInformation` / `GetSupportInformationEx` / `GetSupportName` | Support details |
-| `GetElasticFootingDetail` / `GetElasticMatDetail` / `GetPlateMatDetail` | Spring details |
-| `GetCountOfElasticFooting` / `GetCountOfElasticMat` / `GetCountOfPlateMat` | Spring counts |
+| Function                                                                                 | Purpose              |
+| ---------------------------------------------------------------------------------------- | -------------------- |
+| `CreateSupportFixed` / `CreateSupportPinned` / `CreateSupportFixedBut`                   | Create support types |
+| `CreateElasticFooting` / `CreateElasticMat` / `CreatePlateMat` / `CreateInclinedSupport` | Special supports     |
+| `AssignSupportToNode` / `AssignSupportToEntityList`                                      | Assign support       |
+| `RemoveSupportFromNode` / `DeleteSupport`                                                | Remove support       |
+| `GetSupportCount` / `GetSupportNodes` / `GetSupportType`                                 | Support queries      |
+| `GetSupportInformation` / `GetSupportInformationEx` / `GetSupportName`                   | Support details      |
+| `GetElasticFootingDetail` / `GetElasticMatDetail` / `GetPlateMatDetail`                  | Spring details       |
+| `GetCountOfElasticFooting` / `GetCountOfElasticMat` / `GetCountOfPlateMat`               | Spring counts        |
 
 ---
 
 ## oscommand → staad-analysis
 
-| Function | Purpose |
-|---|---|
-| `PerformAnalysis` | Standard linear analysis |
-| `PerformPDeltaAnalysisEx` / `PerformPDeltaAnalysisNoConverge` | P-Delta analysis |
-| `PerformBucklingAnalysis` / `PerformBucklingAnalysisEx` | Buckling |
-| `PerformCableAnalysis` / `PerformCableAnalysisEx` | Cable analysis |
-| `PerformNonlinearAnalysisEx` | Nonlinear analysis |
-| `PerformDirectAnalysis` | Direct analysis (AISC) |
-| `DeleteAllAnalysisCommands` | Clear analysis commands |
-| `SetCheckIrregularitiesCommand` / `SetCheckSoftStoryCommand` | Seismic checks |
-| `SetFloorDiaphragmBaseCommand` | Diaphragm base |
-| `CreateSteelDesignCommand` | Steel design command |
+| Function                                                      | Purpose                  |
+| ------------------------------------------------------------- | ------------------------ |
+| `PerformAnalysis`                                             | Standard linear analysis |
+| `PerformPDeltaAnalysisEx` / `PerformPDeltaAnalysisNoConverge` | P-Delta analysis         |
+| `PerformBucklingAnalysis` / `PerformBucklingAnalysisEx`       | Buckling                 |
+| `PerformCableAnalysis` / `PerformCableAnalysisEx`             | Cable analysis           |
+| `PerformNonlinearAnalysisEx`                                  | Nonlinear analysis       |
+| `PerformDirectAnalysis`                                       | Direct analysis (AISC)   |
+| `DeleteAllAnalysisCommands`                                   | Clear analysis commands  |
+| `SetCheckIrregularitiesCommand` / `SetCheckSoftStoryCommand`  | Seismic checks           |
+| `SetFloorDiaphragmBaseCommand`                                | Diaphragm base           |
+| `CreateSteelDesignCommand`                                    | Steel design command     |
 
 ---
 
 ## osoutput → staad-results
 
-| Function | Purpose |
-|---|---|
-| `AreResultsAvailable` | Check if analysis has run |
-| `GetNodeDisplacements` / `GetSupportReactions` | Node output |
-| `GetMemberEndForces` / `GetPMemberEndForces` | Beam forces |
-| `GetMinMaxAxialForce` / `GetMinMaxShearForce` / `GetMinMaxBendingMoment` | Min/max forces |
-| `GetIntermediateMemberForcesAtDistance` / `GetMaxBeamStresses` | Intermediate |
-| `GetMemberEndDisplacements` / `GetMaxSectionDisplacement` / `GetIntermediateDeflectionAtDistance` | Deflections |
-| `GetAllPlateCenterStressesAndMoments` / `GetAllPlateCenterForces` | Plate center |
-| `GetPlateCenterVonMisesStresses` / `GetAllPlateCenterPrincipalStressesAndAngles` | Plate principal |
-| `GetPlateCornerForces` / `GetPlateStressAtPoint` | Plate corner/point |
-| `GetAllSolidNormalStresses` / `GetAllSolidShearStresses` / `GetAllSolidVonMisesStresses` | Solid results |
-| `GetNoOfModesExtracted` / `GetModeFrequency` / `GetModalDisplacementAtNode` | Modal results |
-| `GetBucklingFactor` / `GetBucklingModeDisplacementAtNode` / `GetNoOfBucklingFactors` | Buckling results |
-| `GetTimeHistoryResponse` / `GetTimeHistoryResponseMinMax` / `GetTimeHistoryResponseAtTime` | Time-history |
-| `GetNLLoadStep` / `GetNLNodeDisplacements` | Nonlinear results |
-| `GetMemberSteelDesignResults` / `GetMemberSteelDesignRatio` | Steel design output |
-| `GetMultipleMemberSteelDesignResults` / `GetMultipleMemberSteelDesignRatio` | Multi-block design |
-| `GetMemberSteelDesignMaxFailureRatio` / `GetMemberSteelDesignMinFailureRatio` | Model-wide max/min |
-| `GetSteelDesignParameterBlockCount` / `GetSteelDesignParameterBlockNameByIndex` | AISC 360 blocks |
-| `GetStaticCheckResult` / `GetBasePressures` / `GetMatInfluenceAreas` | Foundation results |
-| `GetOutputUnitForForce` / `GetOutputUnitForMoment` / `GetOutputUnitForDisplacement` | Output units |
+| Function                                                                                          | Purpose                   |
+| ------------------------------------------------------------------------------------------------- | ------------------------- |
+| `AreResultsAvailable`                                                                             | Check if analysis has run |
+| `GetNodeDisplacements` / `GetSupportReactions`                                                    | Node output               |
+| `GetMemberEndForces` / `GetPMemberEndForces`                                                      | Beam forces               |
+| `GetMinMaxAxialForce` / `GetMinMaxShearForce` / `GetMinMaxBendingMoment`                          | Min/max forces            |
+| `GetIntermediateMemberForcesAtDistance` / `GetMaxBeamStresses`                                    | Intermediate              |
+| `GetMemberEndDisplacements` / `GetMaxSectionDisplacement` / `GetIntermediateDeflectionAtDistance` | Deflections               |
+| `GetAllPlateCenterStressesAndMoments` / `GetAllPlateCenterForces`                                 | Plate center              |
+| `GetPlateCenterVonMisesStresses` / `GetAllPlateCenterPrincipalStressesAndAngles`                  | Plate principal           |
+| `GetPlateCornerForces` / `GetPlateStressAtPoint`                                                  | Plate corner/point        |
+| `GetAllSolidNormalStresses` / `GetAllSolidShearStresses` / `GetAllSolidVonMisesStresses`          | Solid results             |
+| `GetNoOfModesExtracted` / `GetModeFrequency` / `GetModalDisplacementAtNode`                       | Modal results             |
+| `GetBucklingFactor` / `GetBucklingModeDisplacementAtNode` / `GetNoOfBucklingFactors`              | Buckling results          |
+| `GetTimeHistoryResponse` / `GetTimeHistoryResponseMinMax` / `GetTimeHistoryResponseAtTime`        | Time-history              |
+| `GetNLLoadStep` / `GetNLNodeDisplacements`                                                        | Nonlinear results         |
+| `GetMemberSteelDesignResults` / `GetMemberSteelDesignRatio`                                       | Steel design output       |
+| `GetMultipleMemberSteelDesignResults` / `GetMultipleMemberSteelDesignRatio`                       | Multi-block design        |
+| `GetMemberSteelDesignMaxFailureRatio` / `GetMemberSteelDesignMinFailureRatio`                     | Model-wide max/min        |
+| `GetSteelDesignParameterBlockCount` / `GetSteelDesignParameterBlockNameByIndex`                   | AISC 360 blocks           |
+| `GetStaticCheckResult` / `GetBasePressures` / `GetMatInfluenceAreas`                              | Foundation results        |
+| `GetOutputUnitForForce` / `GetOutputUnitForMoment` / `GetOutputUnitForDisplacement`               | Output units              |
 
 ---
 
 ## osdesign → staad-steel-design
 
-| Function | Purpose |
-|---|---|
-| `CreateDesignBrief` | Create new design brief |
-| `AssignDesignCommand` / `AssignDesignParameter` / `AssignDesignGroup` | Configure design brief |
-| `GetDesignBriefCode` / `GetMemberDesignParameters` | Read design settings |
+| Function                                                              | Purpose                 |
+| --------------------------------------------------------------------- | ----------------------- |
+| `CreateDesignBrief`                                                   | Create new design brief |
+| `AssignDesignCommand` / `AssignDesignParameter` / `AssignDesignGroup` | Configure design brief  |
+| `GetDesignBriefCode` / `GetMemberDesignParameters`                    | Read design settings    |
 
 ---
 
 ## osview → staad-view
 
-| Function | Purpose |
-|---|---|
-| `CopyPicture` | Copy view to clipboard |
-| `ShowFront` / `ShowBack` / `ShowLeft` / `ShowRight` / `ShowPlan` / `ShowIsometric` | Standard orientations |
-| `ShowBottom` / `RotateLeft` / `RotateRight` / `RotateUp` / `RotateDown` | Rotate/orient |
-| `SpinLeft` / `SpinRight` | Spin |
-| `ZoomAll` / `ZoomExtentsMainView` | Zoom |
-| `ShowMember` / `ShowMembers` / `ShowAllMembers` | Show members |
-| `HideMember` / `HideMembers` / `HidePlate` / `HideSolid` / `HideAllMembers` | Hide elements |
-| `SaveView` / `OpenView` / `RenameView` | Saved views |
-| `RefreshView` | Refresh display |
-| `SetInterfaceMode` / `GetInterfaceMode` | Mode (Geometry/Post-processing) |
-| `SetLabel` / `SetDiagramMode` / `SetDesignResults` | Diagram settings |
-| `SetScaleValueByType` / `GetScaleValueByType` / `GetScaleValues` / `SetScaleValues` | Scale settings |
-| `SetSectionView` / `SetUnits` | View options |
-| `GetWindowCount` / `GetWindowTitle` / `SetActiveWindow` / `CloseActiveWindow` | Window management |
-| `SelectByItemList` / `SelectGroup` / `SelectInverse` / `SelectEntitiesConnectedToNode` | View-based selection |
-| `GetApplicationDesktopSize` / `SetWindowPosition` | Window size/position |
+| Function                                                                               | Purpose                                                                        |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `CopyPicture`                                                                          | Copy view to clipboard                                                         |
+| `ExportView`                                                                           | Export view as image file (`.png`/`.jpg`/`.bmp`/`.emf`/`.wmf`, path-validated) |
+| `ShowFront` / `ShowBack` / `ShowLeft` / `ShowRight` / `ShowPlan` / `ShowIsometric`     | Standard orientations                                                          |
+| `ShowBottom` / `RotateLeft` / `RotateRight` / `RotateUp` / `RotateDown`                | Rotate/orient                                                                  |
+| `SpinLeft` / `SpinRight`                                                               | Spin                                                                           |
+| `ZoomAll` / `ZoomExtentsMainView`                                                      | Zoom                                                                           |
+| `ShowMember` / `ShowMembers` / `ShowAllMembers`                                        | Show members                                                                   |
+| `HideMember` / `HideMembers` / `HidePlate` / `HideSolid` / `HideAllMembers`            | Hide elements                                                                  |
+| `SaveView` / `OpenView` / `RenameView`                                                 | Saved views                                                                    |
+| `RefreshView`                                                                          | Refresh display                                                                |
+| `SetInterfaceMode` / `GetInterfaceMode`                                                | Mode (Geometry/Post-processing)                                                |
+| `SetLabel` / `SetDiagramMode` / `SetDesignResults`                                     | Diagram settings                                                               |
+| `SetScaleValueByType` / `GetScaleValueByType` / `GetScaleValues` / `SetScaleValues`    | Scale settings                                                                 |
+| `SetSectionView` / `SetUnits`                                                          | View options                                                                   |
+| `GetWindowCount` / `GetWindowTitle` / `SetActiveWindow` / `CloseActiveWindow`          | Window management                                                              |
+| `SelectByItemList` / `SelectGroup` / `SelectInverse` / `SelectEntitiesConnectedToNode` | View-based selection                                                           |
+| `GetApplicationDesktopSize` / `SetWindowPosition`                                      | Window size/position                                                           |
 
 ---
 
 ## ostable → staad-reports
 
-| Function | Purpose |
-|---|---|
-| `CreateReport` / `DeleteReport` / `SaveReport` / `SaveReportAll` | Report lifecycle |
+| Function                                                                 | Purpose          |
+| ------------------------------------------------------------------------ | ---------------- |
+| `CreateReport` / `DeleteReport` / `SaveReport` / `SaveReportAll`         | Report lifecycle |
 | `AddTable` / `DeleteTable` / `RenameTable` / `ResizeTable` / `SaveTable` | Table management |
-| `SetCellValue` / `GetCellValue` | Cell data |
-| `SetColumnHeader` / `SetRowHeader` / `SetColumnUnitString` | Headers/units |
-| `SetCellTextBold` / `SetCellTextItalic` / `SetCellTextUnderline` | Formatting |
-| `SetCellTextColor` / `SetCellTextSize` / `SetCellTextSizeAll` | Font |
-| `SetCellTextHorzAlignment` / `SetCellTextVertAlignment` | Alignment |
-| `GetReportCount` / `GetTableCount` | Report queries |
+| `SetCellValue` / `GetCellValue`                                          | Cell data        |
+| `SetColumnHeader` / `SetRowHeader` / `SetColumnUnitString`               | Headers/units    |
+| `SetCellTextBold` / `SetCellTextItalic` / `SetCellTextUnderline`         | Formatting       |
+| `SetCellTextColor` / `SetCellTextSize` / `SetCellTextSizeAll`            | Font             |
+| `SetCellTextHorzAlignment` / `SetCellTextVertAlignment`                  | Alignment        |
+| `GetReportCount` / `GetTableCount`                                       | Report queries   |

--- a/src/openstaad_mcp/staad_skills/staad-view/SKILL.md
+++ b/src/openstaad_mcp/staad_skills/staad-view/SKILL.md
@@ -1,6 +1,6 @@
 ﻿---
 name: staad-view
-description: "Use when controlling the STAAD.Pro user interface: camera views, show/hide elements, labels, result diagrams, annotations, screenshots, window management, saved views, display scales, or switching between modeling and post-processing modes. Covers: SetInterfaceMode, ShowIsometric, ShowPlan, ShowFront, ZoomExtentsMainView, ZoomAll, ShowMember, HideMember, ShowAllMembers, SetLabel (node/beam numbers), SetDiagramMode (displacement/moment/shear diagrams), SetDesignResults (utilization ratios), CopyPicture (clipboard), SelectMembersParallelTo, SetSectionView (clipping plane), SaveView, SetWindowPosition. Requires staad-core."
+description: "Use when controlling the STAAD.Pro user interface: camera views, show/hide elements, labels, result diagrams, annotations, screenshots, export to image, window management, saved views, display scales, or switching between modeling and post-processing modes. Covers: SetInterfaceMode, ShowIsometric, ShowPlan, ShowFront, ZoomExtentsMainView, ZoomAll, ShowMember, HideMember, ShowAllMembers, SetLabel (node/beam numbers), SetDiagramMode (displacement/moment/shear diagrams), SetDesignResults (utilization ratios), CopyPicture (clipboard), ExportView (save view as PNG/JPG/BMP/EMF/WMF — path-validated), SelectMembersParallelTo, SetSectionView (clipping plane), SaveView, SetWindowPosition. Requires staad-core."
 ---
 
 # STAAD.Pro View Control
@@ -109,6 +109,34 @@ view.SetSectionView(plane, minVal, maxVal)  # plane: 0=XY, 1=YZ, 2=XZ
 x, y = view.CopyPicture()
 ```
 
+## Export View to File
+
+`ExportView` saves the current view as an image file. It takes a **directory** and a **filename** as separate arguments. The combined path is validated by the sandbox.
+
+```python
+# ExportView(directory, filename, formatCode, flag)
+
+# Export to PNG
+view.ExportView("C:\\exports", "front_view.png", 3, 0)
+
+# Export to JPG
+view.ExportView("C:\\exports", "iso_view.jpg", 2, 0)
+
+# Export to BMP
+view.ExportView("C:\\exports", "plan_view.bmp", 1, 0)
+
+# Export to EMF (vector)
+view.ExportView("C:\\exports", "detail.emf", 4, 0)
+```
+
+**Path rules** (enforced on the combined `directory\filename` — violations raise an error):
+
+- The combined path **must be absolute**
+- The filename **must end with** `.png`, `.jpg`, `.jpeg`, `.bmp`, `.emf`, or `.wmf`
+- UNC paths (`\\\\server\\share\\...`) are **blocked**
+- Paths targeting protected OS directories (`Windows`, `Program Files`, `ProgramData`) are **blocked**
+- Path traversal (`..`) in either directory or filename is **blocked**
+
 ## Window Management
 
 ```python
@@ -161,3 +189,4 @@ view.SetUnits(uType, strUnit)   # e.g. SetUnits(5, "kN")
 - Switch to post-processing mode (`SetInterfaceMode(5)`) before showing result diagrams; always call `staad.ShowApplication()` first
 - Do not try to read back the interface mode after setting it — the value is unreliable; trust that `SetInterfaceMode` applies correctly
 - Selection via `view.SelectByItemList` should be avoided for geometry — use `geo.SelectMultipleBeams` instead
+- `ExportView(directory, filename, ...)` takes a **directory** and **filename** as separate arguments; the combined path must be absolute, end with a supported image extension (`.png`, `.jpg`, `.jpeg`, `.bmp`, `.emf`, `.wmf`), and not target a protected OS directory; UNC paths and `..` traversal are rejected

--- a/tests/sandbox/test_com_proxy.py
+++ b/tests/sandbox/test_com_proxy.py
@@ -4,7 +4,7 @@ Tests for the COM object proxy.
 
 import pytest
 
-from openstaad_mcp.sandbox.com_proxy import COMProxy
+from openstaad_mcp.sandbox.com_proxy import COMProxy, validate_file_path
 
 
 class FakeCOMObj:
@@ -34,7 +34,7 @@ class FakeCOMObj:
         _oleobj_ = "view-dispatch"
 
         @staticmethod
-        def ExportView(path, name, fmt, flag):
+        def ExportView(directory, filename, fmt, flag):
             return True
 
     @staticmethod
@@ -47,6 +47,14 @@ class FakeCOMObj:
 
     @staticmethod
     def OpenSTAADFile(path):
+        return True
+
+    @staticmethod
+    def CloseSTAADFile():
+        return True
+
+    @staticmethod
+    def SaveAs(path):
         return True
 
     @staticmethod
@@ -104,19 +112,227 @@ class TestBlockedDunderAttrs:
 
 
 class TestBlockedDangerousMethods:
-    """Dangerous COM methods must be blocked."""
+    """File-operation COM methods are now allowed with path validation."""
 
-    def test_new_staad_file_blocked(self, proxy):
-        with pytest.raises(AttributeError, match="not allowed"):
-            _ = proxy.NewSTAADFile
+    # -- NewSTAADFile ----------------------------------------------------------
 
-    def test_open_staad_file_blocked(self, proxy):
-        with pytest.raises(AttributeError, match="not allowed"):
-            _ = proxy.OpenSTAADFile
+    def test_new_staad_file_valid_path(self, proxy):
+        assert proxy.NewSTAADFile("C:\\models\\new_model.std", 1, 0) is True
 
-    def test_export_view_blocked(self, proxy):
-        with pytest.raises(AttributeError, match="not allowed"):
-            _ = proxy.ExportView
+    def test_new_staad_file_wrong_extension(self, proxy):
+        with pytest.raises(ValueError, match="extensions"):
+            proxy.NewSTAADFile("C:\\models\\evil.exe", 1, 0)
+
+    def test_new_staad_file_unc_path(self, proxy):
+        with pytest.raises(ValueError, match="UNC"):
+            proxy.NewSTAADFile("\\\\server\\share\\model.std", 1, 0)
+
+    def test_new_staad_file_relative_path(self, proxy):
+        with pytest.raises(ValueError, match="absolute"):
+            proxy.NewSTAADFile("relative\\model.std", 1, 0)
+
+    def test_new_staad_file_traversal(self, proxy):
+        with pytest.raises(ValueError, match="traversal"):
+            proxy.NewSTAADFile("C:\\models\\..\\..\\Windows\\model.std", 1, 0)
+
+    def test_new_staad_file_protected_dir(self, proxy):
+        with pytest.raises(ValueError, match="protected"):
+            proxy.NewSTAADFile("C:\\Windows\\model.std", 1, 0)
+
+    # -- OpenSTAADFile ---------------------------------------------------------
+
+    def test_open_staad_file_valid_path(self, proxy):
+        assert proxy.OpenSTAADFile("C:\\projects\\bridge.std") is True
+
+    def test_open_staad_file_wrong_extension(self, proxy):
+        with pytest.raises(ValueError, match="extensions"):
+            proxy.OpenSTAADFile("C:\\models\\data.txt")
+
+    def test_open_staad_file_program_files(self, proxy):
+        with pytest.raises(ValueError, match="protected"):
+            proxy.OpenSTAADFile("C:\\Program Files\\model.std")
+
+    # -- SaveAs ----------------------------------------------------------------
+
+    def test_save_as_valid_path(self, proxy):
+        assert proxy.SaveAs("D:\\backups\\model_v2.std") is True
+
+    def test_save_as_wrong_extension(self, proxy):
+        with pytest.raises(ValueError, match="extensions"):
+            proxy.SaveAs("C:\\models\\model.zip")
+
+    def test_save_as_protected_dir(self, proxy):
+        with pytest.raises(ValueError, match="protected"):
+            proxy.SaveAs("C:\\ProgramData\\model.std")
+
+    # -- CloseSTAADFile (no path arg — always allowed) -------------------------
+
+    def test_close_staad_file_allowed(self, proxy):
+        assert proxy.CloseSTAADFile() is True
+
+    # -- ExportView (composite path: directory + filename on sub-object) ------
+
+    def test_export_view_valid_png(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.png", 1, 0) is True
+
+    def test_export_view_valid_jpg(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.jpg", 1, 0) is True
+
+    def test_export_view_valid_bmp(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.bmp", 1, 0) is True
+
+    def test_export_view_valid_emf(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.emf", 1, 0) is True
+
+    def test_export_view_valid_jpeg(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.jpeg", 1, 0) is True
+
+    def test_export_view_valid_wmf(self, proxy):
+        view = proxy.View
+        assert view.ExportView("C:\\exports", "view.wmf", 1, 0) is True
+
+    def test_export_view_wrong_extension(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="extensions"):
+            view.ExportView("C:\\exports", "view.exe", 1, 0)
+
+    def test_export_view_unc_dir(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="UNC"):
+            view.ExportView("\\\\server\\share", "view.png", 1, 0)
+
+    def test_export_view_protected_dir(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="protected"):
+            view.ExportView("C:\\Windows", "view.png", 1, 0)
+
+    def test_export_view_traversal_in_dir(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="traversal"):
+            view.ExportView("C:\\exports\\..\\..\\Windows", "view.png", 1, 0)
+
+    def test_export_view_traversal_in_filename(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="traversal"):
+            view.ExportView("C:\\exports", "..\\..\\Windows\\view.png", 1, 0)
+
+    def test_export_view_null_byte_in_filename(self, proxy):
+        view = proxy.View
+        with pytest.raises(ValueError, match="Null bytes"):
+            view.ExportView("C:\\exports", "view.png\x00.exe", 1, 0)
+
+
+class TestValidateFilePathUnit:
+    """Direct unit tests for the validate_file_path function."""
+
+    def test_empty_string_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_file_path("", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_file_path(123, allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_unc_rejected(self):
+        with pytest.raises(ValueError, match="UNC"):
+            validate_file_path("\\\\host\\share\\f.std", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_unc_forward_slash_rejected(self):
+        with pytest.raises(ValueError, match="UNC"):
+            validate_file_path("//host/share/f.std", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_unc_device_path_rejected(self):
+        with pytest.raises(ValueError, match="UNC"):
+            validate_file_path(
+                "\\\\?\\UNC\\host\\share\\f.std", allowed_extensions=frozenset({".std"}), method_name="Test"
+            )
+
+    def test_relative_rejected(self):
+        with pytest.raises(ValueError, match="absolute"):
+            validate_file_path("models\\f.std", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_traversal_rejected(self):
+        with pytest.raises(ValueError, match="traversal"):
+            validate_file_path(
+                "C:\\a\\..\\..\\Windows\\f.std",
+                allowed_extensions=frozenset({".std"}),
+                method_name="Test",
+            )
+
+    def test_wrong_extension_rejected(self):
+        with pytest.raises(ValueError, match="extensions"):
+            validate_file_path("C:\\a\\f.exe", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_no_extension_rejected(self):
+        with pytest.raises(ValueError, match="extensions"):
+            validate_file_path("C:\\a\\noext", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_protected_windows(self):
+        with pytest.raises(ValueError, match="protected"):
+            validate_file_path("C:\\Windows\\f.std", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_protected_program_files(self):
+        with pytest.raises(ValueError, match="protected"):
+            validate_file_path(
+                "C:\\Program Files\\app\\f.std",
+                allowed_extensions=frozenset({".std"}),
+                method_name="Test",
+            )
+
+    def test_protected_program_files_x86(self):
+        with pytest.raises(ValueError, match="protected"):
+            validate_file_path(
+                "C:\\Program Files (x86)\\app\\f.std",
+                allowed_extensions=frozenset({".std"}),
+                method_name="Test",
+            )
+
+    def test_valid_path_passes(self):
+        # Should not raise
+        validate_file_path(
+            "C:\\Users\\me\\models\\test.std", allowed_extensions=frozenset({".std"}), method_name="Test"
+        )
+
+    def test_case_insensitive_extension(self):
+        # .STD should also pass
+        validate_file_path("C:\\models\\TEST.STD", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_case_insensitive_protected_dir(self):
+        with pytest.raises(ValueError, match="protected"):
+            validate_file_path("C:\\WINDOWS\\f.std", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_null_byte_rejected(self):
+        with pytest.raises(ValueError, match="Null bytes"):
+            validate_file_path(
+                "C:\\models\\safe.std\x00.exe", allowed_extensions=frozenset({".std"}), method_name="Test"
+            )
+
+    def test_forward_slash_traversal_rejected(self):
+        with pytest.raises(ValueError, match="traversal"):
+            validate_file_path(
+                "C:/models/../../Windows/f.std",
+                allowed_extensions=frozenset({".std"}),
+                method_name="Test",
+            )
+
+    def test_trailing_spaces_in_extension(self):
+        # Windows strips trailing spaces; "file.std   " becomes "file.std" — must not bypass checks
+        with pytest.raises(ValueError, match="extensions"):
+            validate_file_path("C:\\models\\file.exe ", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_trailing_dot_rejected(self):
+        # "file.std." → os.path.splitext yields extension ".", which is not in the allowlist
+        with pytest.raises(ValueError, match="extensions"):
+            validate_file_path("C:\\models\\file.std.", allowed_extensions=frozenset({".std"}), method_name="Test")
+
+    def test_mixed_case_extension_std(self):
+        # .Std (mixed case) should pass
+        validate_file_path("C:\\models\\test.Std", allowed_extensions=frozenset({".std"}), method_name="Test")
 
 
 class TestUNCPathBlocking:
@@ -128,6 +344,14 @@ class TestUNCPathBlocking:
         # Let's test via a safe getter that doesn't need args
         result = proxy.GetApplicationVersion()
         assert result == "STAAD.Pro V25"
+
+    def test_forward_slash_unc_blocked_on_validated_method(self, proxy):
+        with pytest.raises(ValueError, match="UNC"):
+            proxy.OpenSTAADFile("//server/share/model.std")
+
+    def test_device_path_unc_blocked_on_validated_method(self, proxy):
+        with pytest.raises(ValueError, match="UNC"):
+            proxy.OpenSTAADFile("\\\\?\\UNC\\server\\share\\model.std")
 
 
 class TestAllowedAccess:


### PR DESCRIPTION
This pull request introduces a comprehensive and robust path validation system for COM methods in the `COMProxy` sandbox, replacing the previous blanket blocking of certain file-related methods. Now, file-path arguments for sensitive methods are strictly validated for safety, and the documentation is updated to reflect these changes. The most important changes are grouped below:

**Sandbox Path Validation and COMProxy Security:**

- Introduced a path-validation infrastructure in `com_proxy.py` that enforces strict rules on file-path arguments for sensitive COM methods (e.g., `OpenSTAADFile`, `NewSTAADFile`, `SaveAs`, `ExportView`). Paths must be absolute, have allowed extensions, avoid UNC paths, avoid protected directories, and block path traversal. This replaces the previous approach of blocking these methods entirely.
- Implemented `_ValidatedFileMethodWrapper` to wrap and validate arguments for these methods at runtime, ensuring only safe file operations are allowed.
- Updated `COMProxy.__getattr__` to use the new validation system instead of blocking methods outright. [[1]](diffhunk://#diff-fd62564b5032e6f58d7e99f9c778a823f2ea26c15619fdd7b9e3b1100d002f2fL53-L55) [[2]](diffhunk://#diff-fd62564b5032e6f58d7e99f9c778a823f2ea26c15619fdd7b9e3b1100d002f2fR184-R186)

**Documentation and Skill Map Updates:**

- Updated `SKILL.md` to document which file operations are now path-validated, including explicit rules and usage examples for `OpenSTAADFile`, `NewSTAADFile`, `SaveAs`, and `CloseSTAADFile`.
- Updated `FUNCTION_SKILL_MAP.md` to indicate which functions are path-validated and to clarify table formatting and descriptions for all skill groups, including new notes for `ExportView` and other file-related functions. [[1]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L11-R19) [[2]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L30-R34) [[3]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L64-R68) [[4]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L97-R101) [[5]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L123-R127) [[6]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L138-R142) [[7]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L155-R159) [[8]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L182-R186) [[9]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L192-R198) [[10]](diffhunk://#diff-2a1585369db0e3f6701d9e1566b4e17c1908ccb0029e4a21c78e8a07c5e1a976L215-R220)