### PR TITLE
fix/codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @BentleySystems/bentley-developers
+* @silvestre-perret-bentley @josha-bentley @rgonzalo-orellana


### PR DESCRIPTION
This pull request updates the repository's code ownership to reflect individual maintainers instead of a team.

- Code ownership update:
  * Changed the default code owners from the `@BentleySystems/bentley-developers` team to the individual users `@silvestre-perret-bentley`, `@josha-bentley`, and `@rgonzalo-orellana` in the `.github/CODEOWNERS` file.