### PR TITLE
feat/modelcontextprotocol-registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,44 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ github.event.release.tag_name }}" openstaad-mcp.mcpb --clobber
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download MCPB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openstaad-mcp-mcpb
+
+      - name: Compute SHA-256 of MCPB
+        id: sha
+        run: echo "hash=$(sha256sum openstaad-mcp.mcpb | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Update server.json with version and hash
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          TAG=${{ github.event.release.tag_name }}
+          jq --arg v "$VERSION" \
+             --arg url "https://github.com/BentleySystems/openstaad-mcp/releases/download/${TAG}/openstaad-mcp.mcpb" \
+             --arg hash "${{ steps.sha.outputs.hash }}" \
+             '.version = $v | .packages[0].identifier = $url | .packages[0].fileSha256 = $hash' \
+             server.json > server.tmp && mv server.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.BentleySystems/openstaad-mcp",
+  "title": "OpenSTAAD MCP Server",
+  "description": "MCP server for Bentley STAAD.Pro via the OpenSTAAD API",
+  "repository": {
+    "url": "https://github.com/BentleySystems/openstaad-mcp",
+    "source": "github"
+  },
+  "version": "<AUTO_GENERATED>",
+  "packages": [
+    {
+      "registryType": "mcpb",
+      "identifier": "https://github.com/BentleySystems/openstaad-mcp/releases/download/v<AUTO_GENERATED>/openstaad-mcp.mcpb",
+      "fileSha256": "<AUTO_GENERATED>",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds automated publishing of the MCP server package to the MCP Registry as part of the release workflow, and introduces a new `server.json` metadata file to describe the package. 

See instructions [here](https://github.com/modelcontextprotocol/registry/blob/2b90d93712fe7bd8ce1db1c0129dcca35df2e0a2/docs/modelcontextprotocol-io/quickstart.mdx) and [here](https://github.com/modelcontextprotocol/registry/blob/2b90d93712fe7bd8ce1db1c0129dcca35df2e0a2/docs/modelcontextprotocol-io/github-actions.mdx)

The main changes are:

**CI/CD Workflow Enhancements:**

* Added a new `publish-mcp-registry` job to `.github/workflows/publish.yml` that runs on release events. This job downloads the MCPB artifact, computes its SHA-256 hash, updates the `server.json` file with the version, download URL, and hash, and then publishes the package to the MCP Registry using the `mcp-publisher` tool.

**Package Metadata:**

* Added a new `server.json` file that defines the MCP server package metadata, including schema, name, description, repository information, version, package URL, SHA-256 hash, and transport type. The version, identifier URL, and hash are set to placeholders to be auto-populated during the publish workflow.