### PR TITLE
feat/improving-version-handling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,16 @@ jobs:
           npm install -g @anthropic-ai/mcpb
           New-Item -ItemType Directory -Path mcpb-staging -Force
           Copy-Item dist/openstaad-mcp.exe mcpb-staging/
-          Copy-Item mcpb/manifest.json mcpb-staging/
           Copy-Item -Path assets -Destination mcpb-staging/ -Recurse
           Copy-Item -Path LICENSE.md -Destination mcpb-staging/
           Copy-Item -Path README.md -Destination mcpb-staging/
+
+          $version = "${{ github.event.release.tag_name }}".TrimStart('v')
+          if (-not $version) { $version = (Select-String -Path pyproject.toml -Pattern '^version\s*=\s*"(.+)"$').Matches[0].Groups[1].Value }
+          $manifest = Get-Content mcpb/manifest.json -Raw | ConvertFrom-Json
+          $manifest.version = $version
+          $manifest | ConvertTo-Json -Depth 10 | Set-Content mcpb-staging/manifest.json -Encoding utf8
+
           mcpb pack mcpb-staging/ openstaad-mcp.mcpb
 
       - name: Upload MCPB artifact

--- a/README.md
+++ b/README.md
@@ -277,7 +277,12 @@ ruff format --check .
   npm install -g @anthropic-ai/mcpb
   New-Item -ItemType Directory -Path mcpb-staging -Force
   Copy-Item dist/openstaad-mcp.exe mcpb-staging/
-  Copy-Item mcpb/manifest.json mcpb-staging/
+
+  $version = (Select-String -Path pyproject.toml -Pattern '^version\s*=\s*"(.+)"$').Matches[0].Groups[1].Value
+  $manifest = Get-Content mcpb/manifest.json -Raw | ConvertFrom-Json
+  $manifest.version = $version
+  $manifest | ConvertTo-Json -Depth 10 | Set-Content mcpb-staging/manifest.json -Encoding utf8
+
   mcpb pack mcpb-staging/ openstaad-mcp.mcpb
   ```
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "openstaad-mcp",
     "display_name": "OpenSTAAD MCP Server",
-    "version": "1.1.2",
+    "version": "<AUTO_GENERATED>",
     "description": "MCP server for Bentley STAAD.Pro via the OpenSTAAD API",
     "long_description": "The OpenSTAAD MCP server enables Claude to interact with your STAAD.Pro models and perform various time-consuming tasks like load cases definition, data extraction, repetitive property setting and more.\n\n## Key Features\n- **Fast and flexible**: Enjoy minimal latency, interact with every STAAD.Pro features covered by the OpenSTAAD API.\n- **AI-friendly**: Provides documentation, guidance and feedback via dedicated tools to help your AI agent ramp up quickly on the STAAD.Pro API.\n- **Multi-instance support**: Connects to multiple running STAAD.Pro instances simultaneously to parallelize tasks across models.\n- **Privacy-first**: All processing happens locally on your machine. No data is sent to the cloud. No telemetry.\n\nThis server requires having STAAD.Pro installed locally and running. If you don't already have it, download [STAAD.Pro (www.bentley.com)](https://www.bentley.com/software/staad) to get started.\n\nTerms: Your use of this connector is subject to the [Bentley Systems Terms of Use (www.bentley.com)](https://www.bentley.com/legal/web-properties-terms-of-use).",
     "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openstaad-mcp"
-version = "1.1.2"
+version = "1.1.3"
 description = "MCP server for Bentley STAAD.Pro via OpenSTAAD API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/openstaad_mcp/__init__.py
+++ b/src/openstaad_mcp/__init__.py
@@ -4,5 +4,3 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 See LICENSE.md in the project root for license terms and full copyright notice.
 ---------------------------------------------------------------------------------------------
 """
-
-__version__ = "1.0.0"


### PR DESCRIPTION
This pull request automates and standardizes version management across the project. The main change is to ensure that the `manifest.json` version is automatically injected during the build process, eliminating manual updates and reducing the risk of version mismatches. It also bumps the project version in `pyproject.toml` and removes a redundant version declaration.

Automated version management:

* Added a new step in the GitHub Actions workflow (`.github/workflows/publish.yml`) to automatically inject the release or source version into `mcpb/manifest.json` during the build, replacing the placeholder value.
* Updated `mcpb/manifest.json` to use a placeholder (`<AUTO_GENERATED>`) for the version field, which will be replaced during the build process.

Project version update:

* Bumped the `version` in `pyproject.toml` from `1.1.2` to `1.1.3`.
