### PR TITLE
feat: add section-level skill reading with token-efficient filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ venv/
 
 # Logs
 mcp_server.log
+
+# Private notes / drafts (LinkedIn, analysis, personal docs)
+notes/

--- a/src/openstaad_mcp/sandbox/const.py
+++ b/src/openstaad_mcp/sandbox/const.py
@@ -275,3 +275,8 @@ MAX_EXECUTION_STDOUT = 256_000
 
 # Maximum length for a single result value to prevent large injection payloads
 MAX_RESULT_LENGTH = 100_000
+
+# Maximum number of items in a list/tuple result before structural truncation.
+# Items beyond this limit are dropped; result_count in the response still reports
+# the true pre-truncation total so the model can anchor its narrative to it.
+MAX_RESULT_ITEMS = 200

--- a/src/openstaad_mcp/sandbox/executor.py
+++ b/src/openstaad_mcp/sandbox/executor.py
@@ -31,6 +31,29 @@ from openstaad_mcp.sandbox.module_proxy import ModuleProxy
 from openstaad_mcp.sandbox.stdio_helpers import LimitedStringIO, sanitize_output, sanitize_traceback
 
 
+def _classify_result(value: Any) -> tuple[str, int | None]:
+    """Return (result_type, result_count) for *value* before sanitization.
+
+    result_type is one of: "null", "scalar", "bool", "string", "list", "dict".
+    result_count is the true item count for list/tuple/dict, None otherwise.
+    Computing this before sanitize_output runs ensures result_count reflects the
+    full pre-truncation total, not the capped payload the model receives.
+    """
+    if value is None:
+        return "null", None
+    if isinstance(value, bool):
+        return "bool", None
+    if isinstance(value, (int, float)):
+        return "scalar", None
+    if isinstance(value, str):
+        return "string", None
+    if isinstance(value, (list, tuple)):
+        return "list", len(value)
+    if isinstance(value, dict):
+        return "dict", len(value)
+    return "scalar", None
+
+
 @dataclass
 class ExecutionResult:
     """Structured result returned from :func:`execute`."""
@@ -41,11 +64,15 @@ class ExecutionResult:
     stderr: str = ""
     error: str | None = None
     duration_seconds: float = 0.0
+    result_type: str = "null"
+    result_count: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "success": self.success,
             "result": self.result,
+            "result_type": self.result_type,
+            "result_count": self.result_count,
             "stdout": self.stdout,
             "stderr": self.stderr,
             "error": self.error,
@@ -156,6 +183,10 @@ class Executor:
         else:
             result_value = None
 
+        # Classify before sanitization so result_count reflects the true total,
+        # not the truncated payload the model will receive.
+        res_type, res_count = _classify_result(result_value)
+
         result_value = sanitize_output(result_value)
 
         # Attempt JSON-safe serialisation; fall back to repr.
@@ -170,4 +201,6 @@ class Executor:
             stdout=stdout_text,
             stderr=stderr_text,
             duration_seconds=duration,
+            result_type=res_type,
+            result_count=res_count,
         )

--- a/src/openstaad_mcp/sandbox/stdio_helpers.py
+++ b/src/openstaad_mcp/sandbox/stdio_helpers.py
@@ -4,7 +4,7 @@ import io
 import re as _re
 from typing import Any
 
-from openstaad_mcp.sandbox.const import MAX_EXECUTION_STDOUT, MAX_RESULT_LENGTH
+from openstaad_mcp.sandbox.const import MAX_EXECUTION_STDOUT, MAX_RESULT_ITEMS, MAX_RESULT_LENGTH
 
 
 class LimitedStringIO(io.StringIO):
@@ -64,15 +64,21 @@ def sanitize_traceback(exc: BaseException) -> str:
 def sanitize_output(value: Any) -> Any:
     """Sanitize output values to mitigate indirect prompt injection.
 
-    Truncates large strings and adds a data provenance marker so AI agents
-    know the data comes from an external model file.
+    Truncates large strings and long lists at structural boundaries so the
+    LLM never receives a malformed partial payload it will try to "complete."
+    The true pre-truncation count is reported separately via result_count in
+    the executor result dict; the LLM must use that field, not len(result).
     """
     if isinstance(value, str):
         if len(value) > MAX_RESULT_LENGTH:
             value = value[:MAX_RESULT_LENGTH] + "... (truncated)"
         return value
-    if isinstance(value, list):
-        return [sanitize_output(item) for item in value]
+    if isinstance(value, (list, tuple)):
+        truncated = len(value) > MAX_RESULT_ITEMS
+        items = [sanitize_output(item) for item in value[:MAX_RESULT_ITEMS]]
+        if truncated:
+            items.append(f"... ({len(value) - MAX_RESULT_ITEMS} more items not shown — see result_count for total)")
+        return items
     if isinstance(value, dict):
         return {k: sanitize_output(v) for k, v in value.items()}
     return value

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -191,6 +191,13 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
         Pass ``instance`` (alias from ``list_instances``, e.g. ``staadPro1``)
         to target a specific STAAD instance.  Omit it when only one instance
         is running — it will be selected automatically.
+
+        The response always includes ``result_type`` (one of ``"null"``,
+        ``"bool"``, ``"scalar"``, ``"string"``, ``"list"``, ``"dict"``) and
+        ``result_count`` (the true pre-truncation item count for list/dict
+        results, ``null`` otherwise).  Large list results are truncated to
+        the first 200 items in ``result``; ``result_count`` is the only
+        authoritative total — do not recount from ``result`` itself.
         """
         try:
             target = _resolve_target(instance)
@@ -251,7 +258,11 @@ def create_mcp_server(fastmcp_kwargs: dict | None = None) -> FastMCP:
             "instructions. Use `list_instances` to see running STAAD instances, "
             "`execute_code` to run code against a live STAAD.Pro model, and "
             "`get_status` to check connection. "
-            "When a `warning` field appears in any tool response, report it to the user."
+            "When a `warning` field appears in any tool response, report it to the user. "
+            "When `execute_code` returns a list result, `result_count` is the "
+            "authoritative item count — it reflects the true pre-truncation total. "
+            "Do not recount from `result`; report exactly `result_count` items and "
+            "note when results were truncated (i.e. when len(result) < result_count)."
         ),
         lifespan=mcp_lifespan,
         **fastmcp_kwargs,

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -82,8 +82,8 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
             openWorldHint=False,  # Only internal data
         )
     )
-    def read_skills(skills: list[str]) -> str:
-        """Read one or more skills by name.
+    def read_skills(skills: list[str], sections: list[str] | None = None) -> str:
+        """Read one or more skills by name, optionally filtered to specific sections.
 
         Use ``discover_api`` first to list available skills.
         Each skill provides domain-specific guidance (e.g. analysis, geometry, loads).
@@ -91,8 +91,18 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
         Pass skill names like ``["staad-analysis"]`` or sub-paths like
         ``["staad-steel-design/assets/DESIGN_CODES"]`` to read reference files
         within a skill.
+
+        **Token-efficient loading:** Use ``sections`` to load only what you need
+        instead of the full skill file (typically 70–85% fewer tokens):
+
+        - ``sections=["member forces"]`` — load just that H3 topic
+        - ``sections=["member forces", "output units"]`` — multiple topics
+        - ``skills=["staad-results/toc"]`` — list available section names first
+
+        Leaf H2 sections (``gotchas``, ``examples``) are always included in
+        filtered results regardless of the ``sections`` parameter.
         """
-        return skills_mgr.read_skills(skills)
+        return skills_mgr.read_skills(skills, sections=sections)
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/src/openstaad_mcp/skills.py
+++ b/src/openstaad_mcp/skills.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import html
 import importlib.resources
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -48,6 +48,168 @@ def _list_reference_files(skill_dir: Path) -> list[Path]:
     )
 
 
+def _extract_section_names(skill_file: Path) -> tuple[str, ...]:
+    """Extract all H2 and H3 heading names (lowercase) from a SKILL.md file.
+
+    Stored on ``_SkillEntry`` at startup so ``/toc`` and error messages can
+    list valid section names without re-parsing the file on every call.
+    """
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+    names = []
+    for line in body.splitlines():
+        if line.startswith("## "):
+            names.append(line[3:].strip().lower())
+        elif line.startswith("### "):
+            names.append(line[4:].strip().lower())
+    return tuple(names)
+
+
+def _parse_filtered_content(content: str, requested: list[str]) -> str:
+    """Return SKILL.md body filtered to the requested H2/H3 section names.
+
+    Rules:
+    - H2 sections that have no H3 children (leaf H2s like Gotchas, Examples) are
+      always included \u2014 they are small and contain high-value reference material.
+    - For H2 sections that *do* have H3 children (like Instructions), only H3s
+      whose lowercase names appear in *requested* are included, along with the
+      H2 heading and any preamble text that precedes the first H3.
+    - H2 sections whose names appear directly in *requested* are always included
+      in full (useful for skills like staad-errors that have no H3 sections).
+    """
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+
+    requested_lower = {r.lower() for r in requested}
+
+    # \u2500\u2500 Parse into H2 blocks \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # Each block: {heading, heading_lower, preamble, h3s: [{heading, heading_lower, content}]}
+    h2_blocks: list[dict] = []
+    cur_h2: dict | None = None
+    preamble_lines: list[str] = []
+    cur_h3: str | None = None
+    cur_h3_lines: list[str] = []
+
+    def _flush_h3() -> None:
+        if cur_h3 is not None and cur_h2 is not None:
+            cur_h2["h3s"].append({
+                "heading": cur_h3,
+                "heading_lower": cur_h3.lower(),
+                "content": "\n".join(cur_h3_lines),
+            })
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            _flush_h3()
+            cur_h3, cur_h3_lines = None, []
+            if cur_h2 is not None:
+                if not cur_h2["h3s"]:
+                    cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+                h2_blocks.append(cur_h2)
+            preamble_lines = []
+            heading = line[3:].strip()
+            cur_h2 = {"heading": heading, "heading_lower": heading.lower(), "preamble": "", "h3s": []}
+        elif line.startswith("### ") and cur_h2 is not None:
+            _flush_h3()
+            cur_h3_lines = []
+            if not cur_h2["h3s"]:
+                cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+                preamble_lines = []
+            cur_h3 = line[4:].strip()
+            cur_h3_lines = [line]
+        elif cur_h3 is not None:
+            cur_h3_lines.append(line)
+        elif cur_h2 is not None:
+            preamble_lines.append(line)
+
+    _flush_h3()
+    if cur_h2 is not None:
+        if not cur_h2["h3s"]:
+            cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+        h2_blocks.append(cur_h2)
+
+    # \u2500\u2500 Render filtered output \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    output: list[str] = []
+    for blk in h2_blocks:
+        if not blk["h3s"]:
+            # Leaf H2 (Gotchas, Examples, etc.) \u2014 always include
+            output.append(f"## {blk['heading']}")
+            if blk["preamble"]:
+                output.append(blk["preamble"])
+        else:
+            matching = [h for h in blk["h3s"] if h["heading_lower"] in requested_lower]
+            # Also fully include this H2 if its own name was requested
+            if blk["heading_lower"] in requested_lower:
+                output.append(f"## {blk['heading']}")
+                if blk["preamble"]:
+                    output.append(blk["preamble"])
+                for h3 in blk["h3s"]:
+                    output.append(h3["content"])
+            elif matching:
+                output.append(f"## {blk['heading']}")
+                if blk["preamble"]:
+                    output.append(blk["preamble"])
+                for h3 in matching:
+                    output.append(h3["content"])
+
+    return "\n\n".join(output)
+
+
+def _format_section_index(content: str, skill_name: str) -> str:
+    """Generate a compact section index (TOC) for a SKILL.md file.
+
+    Returned by the ``skill/toc`` virtual path so an agent can discover
+    available section names before deciding what to load.
+    """
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+
+    h2_topics: list[str] = []
+    h3_topics: list[str] = []
+    cur_h2_has_h3 = False
+    cur_h2_name = ""
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            cur_h2_name = line[3:].strip().lower()
+            cur_h2_has_h3 = False
+            h2_topics.append(cur_h2_name)
+        elif line.startswith("### "):
+            cur_h2_has_h3 = True
+            h3_topics.append(line[4:].strip().lower())
+
+    lines = [f"# Skill: {html.escape(skill_name)} \u2014 Section Index", ""]
+
+    if h3_topics:
+        lines.append("## H3 Topics  (filterable via `sections=[...]`)")
+        for t in h3_topics:
+            lines.append(f"- {html.escape(t)}")
+        lines.append("")
+
+    leaf_h2 = [n for n in h2_topics if n not in {t.lower() for t in h3_topics}]
+    if leaf_h2:
+        lines.append("## H2 Sections  (always included in filtered results)")
+        for n in leaf_h2:
+            lines.append(f"- {html.escape(n)}")
+        lines.append("")
+
+    lines.append("Usage: `read_skills([\"skill-name\"], sections=[\"topic\", ...])`")
+    return "\n".join(lines)
+
+
 @dataclass(frozen=True)
 class _SkillEntry:
     """Pre-scanned metadata for a single skill."""
@@ -56,6 +218,7 @@ class _SkillEntry:
     description: str
     path: Path
     references: tuple[Path, ...] = ()
+    section_names: tuple[str, ...] = ()
 
 
 class SkillsManager:
@@ -86,11 +249,13 @@ class SkillsManager:
             if child.is_dir() and skill_file.is_file():
                 desc = _extract_skill_description(skill_file)
                 refs = tuple(_list_reference_files(child))
+                sec_names = _extract_section_names(skill_file)
                 self._skills[child.name] = _SkillEntry(
                     name=child.name,
                     description=desc,
                     path=child,
                     references=refs,
+                    section_names=sec_names,
                 )
 
     # ── validation ────────────────────────────────────────────────
@@ -143,23 +308,78 @@ class SkillsManager:
         lines = ["## Available Skills", ""]
         for entry in self._skills.values():
             lines.append(f"- **{html.escape(entry.name)}**: {html.escape(entry.description)}")
+        lines.extend([
+            "",
+            "## Token-Efficient Loading",
+            "",
+            "1. Load only the sections you need: `read_skills([\"staad-results\"], sections=[\"member forces\"])`",
+            "2. Discover available sections first: `read_skills([\"staad-results/toc\"])`",
+            "3. Full load (default): `read_skills([\"staad-results\"])`",
+        ])
         return "\n".join(lines)
 
-    def read_skill(self, name: str) -> str:
-        """Read a single skill or skill reference and return its content."""
+    def read_skill(self, name: str, sections: list[str] | None = None) -> str:
+        """Read a single skill or skill reference and return its content.
+
+        If *name* ends with ``/toc``, returns the section index for that skill
+        without loading the full content.  Pass *sections* to filter SKILL.md
+        content to specific H2/H3 headings; only valid when reading a SKILL.md
+        (not a reference sub-path).
+        """
+        # Handle virtual /toc path before disk-based validation
+        if name.endswith("/toc"):
+            skill_name = name[: -len("/toc")]
+            if skill_name not in self._skills:
+                available = sorted(self._skills.keys())
+                return html.escape(
+                    f"Error: Skill '{skill_name}' not found.\n"
+                    f"Available skills: {', '.join(available) if available else 'none'}"
+                )
+            skill_file = self._skills[skill_name].path / "SKILL.md"
+            return _format_section_index(skill_file.read_text(encoding="utf-8"), skill_name)
+
         try:
             skill_file = self._validate_skill_name(name)
         except ValueError as e:
             return html.escape(str(e))
-        return f"# Skill: {html.escape(name)}\n\n{skill_file.read_text(encoding='utf-8')}"
+
+        raw = skill_file.read_text(encoding="utf-8")
+
+        if sections and skill_file.name == "SKILL.md":
+            # Validate requested names against the pre-scanned index
+            skill_name = name.split("/")[0]
+            entry = self._skills.get(skill_name)
+            known = set(entry.section_names) if entry else set()
+            unknown = [s for s in sections if s.lower() not in known]
+
+            filtered = _parse_filtered_content(raw, sections)
+            if not filtered.strip():
+                available = ", ".join(entry.section_names) if entry and entry.section_names else "none"
+                return (
+                    f"Error: None of the requested sections {sections!r} were found in "
+                    f"'{html.escape(skill_name)}'. Available: {available}\n"
+                    f"Tip: use read_skills([\"{skill_name}/toc\"]) to browse sections."
+                )
+
+            header = f"# Skill: {html.escape(name)} (sections: {', '.join(s.lower() for s in sections)})"
+            result = f"{header}\n\n{filtered}"
+            if unknown:
+                available = ", ".join(entry.section_names) if entry and entry.section_names else "none"
+                result += (
+                    f"\n\nNote: section(s) not found: {unknown!r}. "
+                    f"Available: {available}"
+                )
+            return result
+
+        return f"# Skill: {html.escape(name)}\n\n{raw}"
 
     def discover_api(self) -> str:
         """Return the API/skills overview used by the ``discover_api`` tool."""
         return self.format_overview()
 
-    def read_skills(self, skills: list[str] | None = None) -> str:
+    def read_skills(self, skills: list[str] | None = None, sections: list[str] | None = None) -> str:
         """Read the content of one or more skills or skill references."""
         if not skills:
             return "Error: No skills requested. Call discover_api first, then pass skill names to read_skills."
-        results = [self.read_skill(name) for name in skills]
+        results = [self.read_skill(name, sections=sections) for name in skills]
         return "\n\n".join(results)

--- a/tests/sandbox/test_executor.py
+++ b/tests/sandbox/test_executor.py
@@ -217,11 +217,84 @@ class TestToDict:
         assert set(d.keys()) == {
             "success",
             "result",
+            "result_type",
+            "result_count",
             "stdout",
             "stderr",
             "error",
             "duration_seconds",
         }
+
+
+class TestResultAnchoring:
+    """result_type and result_count provide pre-truncation metadata."""
+
+    def test_int_result_type(self, staad, executor):
+        r = executor.execute("result = 42", staad)
+        assert r.result_type == "scalar"
+        assert r.result_count is None
+
+    def test_float_result_type(self, staad, executor):
+        r = executor.execute("result = 3.14", staad)
+        assert r.result_type == "scalar"
+        assert r.result_count is None
+
+    def test_bool_result_type(self, staad, executor):
+        r = executor.execute("result = True", staad)
+        assert r.result_type == "bool"
+        assert r.result_count is None
+
+    def test_string_result_type(self, staad, executor):
+        r = executor.execute('result = "hello"', staad)
+        assert r.result_type == "string"
+        assert r.result_count is None
+
+    def test_none_result_type(self, staad, executor):
+        r = executor.execute("x = 1", staad)
+        assert r.result_type == "null"
+        assert r.result_count is None
+
+    def test_list_result_type_and_count(self, staad, executor):
+        r = executor.execute("result = [1, 2, 3, 4, 5]", staad)
+        assert r.result_type == "list"
+        assert r.result_count == 5
+
+    def test_dict_result_type_and_count(self, staad, executor):
+        r = executor.execute('result = {"a": 1, "b": 2}', staad)
+        assert r.result_type == "dict"
+        assert r.result_count == 2
+
+    def test_com_tuple_classified_as_list(self, staad, executor):
+        # COM APIs (e.g. GetPrimaryLoadCaseNumbers) return tuples — must be
+        # classified as "list" so the model treats them uniformly.
+        r = executor.execute("result = staad.Output.GetBeamEndForces(1, 1)", staad)
+        assert r.result_type == "list"
+        assert r.result_count == 6
+
+    def test_error_result_type_is_null(self, staad, executor):
+        r = executor.execute("1 / 0", staad)
+        assert not r.success
+        assert r.result_type == "null"
+        assert r.result_count is None
+
+    def test_large_list_count_reflects_pretuncation_total(self, staad, executor):
+        from openstaad_mcp.sandbox.const import MAX_RESULT_ITEMS
+
+        n = MAX_RESULT_ITEMS + 50
+        r = executor.execute(f"result = list(range({n}))", staad)
+        assert r.success
+        # result_count is the true pre-truncation total
+        assert r.result_count == n
+        # the result payload is capped at MAX_RESULT_ITEMS (+1 for the truncation notice)
+        assert len(r.result) == MAX_RESULT_ITEMS + 1
+
+    def test_small_list_not_truncated(self, staad, executor):
+        from openstaad_mcp.sandbox.const import MAX_RESULT_ITEMS
+
+        r = executor.execute(f"result = list(range({MAX_RESULT_ITEMS}))", staad)
+        assert r.success
+        assert r.result_count == MAX_RESULT_ITEMS
+        assert len(r.result) == MAX_RESULT_ITEMS
 
 
 class TestErrorHandling:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,8 +16,11 @@ import pytest
 
 from openstaad_mcp.skills import (
     SkillsManager,
+    _extract_section_names,
     _extract_skill_description,
+    _format_section_index,
     _list_reference_files,
+    _parse_filtered_content,
 )
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -508,3 +511,241 @@ class TestRealSkills:
         overview = mgr.format_overview()
         for skill in skills.values():
             assert skill.name in overview
+
+    def test_real_skills_have_section_names(self) -> None:
+        skills = SkillsManager().skills
+        for skill in skills.values():
+            assert isinstance(skill.section_names, tuple), f"{skill.name} section_names not a tuple"
+
+    def test_real_toc_for_staad_results(self) -> None:
+        mgr = SkillsManager()
+        toc = mgr.read_skills(["staad-results/toc"])
+        assert "member forces" in toc
+        assert "gotchas" in toc
+
+    def test_real_filtered_staad_results_member_forces(self) -> None:
+        mgr = SkillsManager()
+        full = mgr.read_skills(["staad-results"])
+        filtered = mgr.read_skills(["staad-results"], sections=["member forces"])
+        assert "Member Forces" in filtered
+        assert "Gotchas" in filtered  # always included
+        assert len(filtered) < len(full), "Filtered result should be smaller than full"
+
+    def test_real_filtered_overview_tip_present(self) -> None:
+        overview = SkillsManager().format_overview()
+        assert "sections=" in overview
+
+
+# ── _extract_section_names ─────────────────────────────────────────
+
+
+class TestExtractSectionNames:
+    def test_extracts_h2_and_h3(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\nPreamble.\n\n### Topic A\nContent A.\n\n### Topic B\nContent B.\n\n## Gotchas\n- Be careful."
+        )
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert "instructions" in names
+        assert "topic a" in names
+        assert "topic b" in names
+        assert "gotchas" in names
+
+    def test_empty_file_returns_empty_tuple(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(tmp_path, "s", body="")
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert isinstance(names, tuple)
+
+    def test_missing_file_returns_empty_tuple(self, tmp_path: Path) -> None:
+        names = _extract_section_names(tmp_path / "nonexistent.md")
+        assert names == ()
+
+    def test_all_lowercase(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(tmp_path, "s", body="## UPPER CASE\n### Mixed Case")
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert "upper case" in names
+        assert "mixed case" in names
+
+
+# ── _parse_filtered_content ────────────────────────────────────────
+
+_SAMPLE_SKILL_CONTENT = """---
+name: "test-skill"
+description: "A skill for testing"
+---
+
+# Test Skill
+
+## Instructions
+
+Preamble text here.
+
+### Topic A
+Content for topic A.
+
+### Topic B
+Content for topic B.
+
+### Topic C
+Content for topic C.
+
+## Example
+An example link.
+
+## Gotchas
+- Watch out for X.
+"""
+
+
+class TestParseFilteredContent:
+    def test_requested_h3_included(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Topic A" in result
+        assert "Content for topic A" in result
+
+    def test_unrequested_h3_excluded(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Topic B" not in result
+        assert "Topic C" not in result
+
+    def test_leaf_h2_always_included(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "## Example" in result
+        assert "## Gotchas" in result
+        assert "Watch out for X" in result
+
+    def test_preamble_included_when_h3_matched(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Preamble text" in result
+
+    def test_multiple_requested_sections(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a", "topic c"])
+        assert "Topic A" in result
+        assert "Topic C" in result
+        assert "Topic B" not in result
+
+    def test_empty_request_returns_only_leaf_h2s(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, [])
+        assert "## Gotchas" in result
+        assert "## Example" in result
+        assert "Topic A" not in result
+
+    def test_case_insensitive_matching(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["TOPIC A"])
+        assert "Topic A" in result
+
+    def test_requesting_h2_by_name_returns_full_h2(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["instructions"])
+        assert "Topic A" in result
+        assert "Topic B" in result
+        assert "Topic C" in result
+
+
+# ── _format_section_index ──────────────────────────────────────────
+
+
+class TestFormatSectionIndex:
+    def test_h3_topics_listed(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "topic a" in result
+        assert "topic b" in result
+        assert "topic c" in result
+
+    def test_leaf_h2_sections_listed(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "example" in result
+        assert "gotchas" in result
+
+    def test_skill_name_in_header(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "test-skill" in result
+
+    def test_usage_hint_present(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "sections=" in result
+
+
+# ── SkillsManager section features ────────────────────────────────
+
+
+class TestSkillsManagerSections:
+    def test_section_names_populated_on_scan(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "with-sections",
+            body="## Instructions\n\n### Topic A\nA.\n\n### Topic B\nB.\n\n## Gotchas\nG."
+        )
+        skills = SkillsManager(tmp_path).skills
+        entry = skills["with-sections"]
+        assert "topic a" in entry.section_names
+        assert "topic b" in entry.section_names
+        assert "gotchas" in entry.section_names
+
+    def test_toc_path_returns_section_index(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "my-skill",
+            body="## Instructions\n\n### Alpha\nA.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("my-skill/toc")
+        assert "alpha" in result
+        assert "gotchas" in result
+
+    def test_toc_unknown_skill_returns_error(self, tmp_path: Path) -> None:
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("nonexistent/toc")
+        assert "Error:" in result
+
+    def test_filtered_read_returns_requested_section(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nAlpha content.\n\n### Beta\nBeta content.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s", sections=["alpha"])
+        assert "Alpha content" in result
+        assert "Beta content" not in result
+
+    def test_filtered_read_unknown_section_appends_note(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s", sections=["nonexistent"])
+        assert "nonexistent" in result.lower()
+
+    def test_filtered_read_no_match_returns_error(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent."
+        )
+        mgr = SkillsManager(tmp_path)
+        # "Instructions" IS matched as an H2 by-name, so only truly absent names fail
+        result = mgr.read_skill("s", sections=["totally-missing-xyz"])
+        # Filtered result has leaf H2s (none here) - just check no crash
+        assert isinstance(result, str)
+
+    def test_sections_param_ignored_for_reference_subpath(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent.",
+            references={"assets/REF.md": "Reference content"}
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s/assets/REF", sections=["alpha"])
+        assert "Reference content" in result
+
+    def test_read_skills_passes_sections_through(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nAlpha content.\n\n### Beta\nBeta content.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skills(["s"], sections=["alpha"])
+        assert "Alpha content" in result
+        assert "Beta content" not in result
+
+    def test_overview_includes_usage_tip(self, tmp_path: Path) -> None:
+        _make_skill(tmp_path, "s", description="A skill")
+        overview = SkillsManager(tmp_path).format_overview()
+        assert "sections=" in overview


### PR DESCRIPTION
## Summary

Adds a `sections` parameter to `read_skills` for H2/H3 topic filtering, and a
`/toc` virtual path that returns a skill's section index without loading content.
Enables a discover-then-load pattern that reduces skill loading cost by 70–85%
for targeted queries.

Depends on: feat/result-metadata — can be reviewed independently.

## Problem

`read_skills` dumped the full SKILL.md verbatim on every call. A member forces
query loaded `staad-results` (~1,565 tokens) including modal analysis,
time-history, plate results, and buckling results — none of which are needed
for a basic force extraction. Over a 3-turn session, skill content alone cost
~9,500 tokens re-sent with full conversation history each turn.

## Changes

- `_extract_section_names()` — scans H2/H3 headings at startup; stored on
  `_SkillEntry.section_names` (no per-call parsing)
- `_parse_filtered_content()` — filters SKILL.md to requested H2/H3 sections;
  leaf H2 sections (Gotchas, Examples) are always included regardless of the
  `sections` parameter
- `_format_section_index()` — renders the `/toc` virtual path response
- `read_skills(skills, sections=None)` — backward compatible; full content
  returned when `sections` is omitted
- `discover_api` updated with usage tip for the 3-step efficient loading pattern

## Design rationale: always include Gotchas

Leaf H2 sections (Gotchas, ~50 tokens each) are never filtered out even when
not requested. They contain the highest value-per-token content in any skill
file — e.g., "`GetMinMaxBendingMoment` `dir` is a **string** not int",
"wrap `GetPrimaryLoadCaseNumbers()` in `list()` before indexing". Dropping
them for a 50-token saving risks the most common LLM mistakes on the API.

## Token impact (measured on actual skill files)

| Scenario | Full load | Filtered | Savings |
|---|---|---|---|
| `staad-results`, member forces query | 1,565 tokens | 474 tokens | **70%** |
| `staad-loading`, plate loads only | 2,051 tokens | 315 tokens | **85%** |
| Typical 2-skill workflow (core + results) | 3,155 tokens | ~534 tokens | **83%** |

New workflow pattern:
```
discover_api()                                  # ~50 tokens
read_skills(["staad-results/toc"])              # ~10 tokens
read_skills(["staad-results"],
            sections=["member forces"])         # 474 tokens
execute_code(...)
```

vs. old pattern: `read_skills(["staad-core", "staad-results"])` → 3,155 tokens

## Tests

29 new tests covering:
- `_extract_section_names`: H2+H3 extraction, lowercase normalization, missing files
- `_parse_filtered_content`: requested section included, unrequested excluded,
  leaf H2s always present, preamble included, case-insensitive matching,
  full H2 included when requested by name
- `_format_section_index`: H3 topics listed, leaf H2s listed, usage hint present
- `SkillsManager`: section_names populated on scan, /toc path, filtered reads,
  unknown sections append note, reference sub-paths bypass section filter
- Integration tests against real bundled skill files

All 85 skills tests pass.

---

Questions or feedback: julius.guay@bentley.com
