### PR TITLE
feat: add named domain reporting tools for common structural queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ venv/
 
 # Logs
 mcp_server.log
+
+# Private notes / drafts (LinkedIn, analysis, personal docs)
+notes/

--- a/src/openstaad_mcp/domain_tools.py
+++ b/src/openstaad_mcp/domain_tools.py
@@ -1,0 +1,280 @@
+"""
+---------------------------------------------------------------------------------------------
+Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+See LICENSE.md in the project root for license terms and full copyright notice.
+---------------------------------------------------------------------------------------------
+
+Named domain tools for common structural engineering queries.
+
+Each public ``fetch_*`` function takes a raw OpenSTAAD COM object (or a
+duck-typed mock) and returns a JSON-serialisable dict.  These functions are
+pure data-extractors — they perform no mutation and require only that analysis
+results already exist (checked via ``AreResultsAvailable``).
+
+The response envelope mirrors the PR 1 contract on ``execute_code``:
+  - A human-readable summary header (units, counts)
+  - A detail array capped at ``_MAX_ITEMS`` before serialisation
+  - A pre-cap ``result_count`` so the LLM can report the true total
+
+For ``fetch_design_summary``, **failures are never dropped** when the detail
+list is truncated.  Passing members fill any remaining capacity.  This follows
+the hallucination-prevention rule in the design guide: silently suppressing a
+failing member is a safety regression, not a token saving.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Matches MAX_RESULT_ITEMS in sandbox/const.py so the payload cap is
+# consistent across execute_code results and domain tool results.
+_MAX_ITEMS = 200
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _as_list(value: Any) -> list:
+    """Convert a COM tuple or list result to a plain Python list."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _round_forces(raw: Any) -> dict[str, float]:
+    """Map a 6-element force/moment vector to a labelled dict."""
+    v = _as_list(raw)
+    if len(v) < 6:
+        v = v + [0.0] * (6 - len(v))
+    return {
+        "FX": round(float(v[0]), 6),
+        "FY": round(float(v[1]), 6),
+        "FZ": round(float(v[2]), 6),
+        "MX": round(float(v[3]), 6),
+        "MY": round(float(v[4]), 6),
+        "MZ": round(float(v[5]), 6),
+    }
+
+
+# ── public fetch functions ────────────────────────────────────────────
+
+
+def fetch_model_summary(staad: Any) -> dict[str, Any]:
+    """Return geometry counts, units, and file info for the open model."""
+    geo = staad.Geometry
+    return {
+        "model_path": staad.GetSTAADFile(),
+        "staad_version": staad.GetApplicationVersion(),
+        "units": staad.GetBaseUnit(),
+        "axis_up": "Z" if geo.IsZUp() else "Y",
+        "node_count": geo.GetNodeCount(),
+        "beam_count": geo.GetMemberCount(),
+        "plate_count": geo.GetPlateCount(),
+        "solid_count": geo.GetSolidCount(),
+    }
+
+
+def fetch_member_forces(
+    staad: Any,
+    member_ids: list[int] | None = None,
+    load_cases: list[int] | None = None,
+) -> dict[str, Any]:
+    """Return end-forces for each member × load-case combination.
+
+    Parameters
+    ----------
+    member_ids:
+        Beam IDs to query.  Defaults to all beams in the model.
+    load_cases:
+        Primary load case numbers to query.  Defaults to all cases.
+    """
+    out = staad.Output
+    load = staad.Load
+    geo = staad.Geometry
+
+    if not out.AreResultsAvailable():
+        return {"error": "Results not available. Run analysis first (see run_analysis tool)."}
+
+    all_beams = member_ids if member_ids is not None else _as_list(geo.GetBeamList())
+    all_lcs = load_cases if load_cases is not None else _as_list(load.GetPrimaryLoadCaseNumbers())
+
+    try:
+        force_unit = out.GetOutputUnitForForce()
+        moment_unit = out.GetOutputUnitForMoment()
+    except Exception:
+        force_unit = "unknown"
+        moment_unit = "unknown"
+
+    # Compute true total BEFORE the cap — this is the pre-truncation count.
+    result_count = len(all_beams) * len(all_lcs)
+    items: list[dict[str, Any]] = []
+
+    for bid in all_beams:
+        if len(items) >= _MAX_ITEMS:
+            break
+        for lc in all_lcs:
+            if len(items) >= _MAX_ITEMS:
+                break
+            try:
+                start_raw = out.GetMemberEndForces(bid, 0, lc, 0)
+                end_raw = out.GetMemberEndForces(bid, 1, lc, 0)
+                items.append({
+                    "member_id": int(bid),
+                    "load_case": int(lc),
+                    "start": _round_forces(start_raw),
+                    "end": _round_forces(end_raw),
+                })
+            except Exception as exc:
+                items.append({
+                    "member_id": int(bid),
+                    "load_case": int(lc),
+                    "error": str(exc),
+                })
+
+    return {
+        "force_unit": force_unit,
+        "moment_unit": moment_unit,
+        "member_count": len(all_beams),
+        "load_case_count": len(all_lcs),
+        "result_count": result_count,
+        "showing": len(items),
+        "truncated": len(items) < result_count,
+        "forces": items,
+    }
+
+
+def fetch_support_reactions(
+    staad: Any,
+    node_ids: list[int] | None = None,
+    load_cases: list[int] | None = None,
+) -> dict[str, Any]:
+    """Return support reactions for each support node × load-case combination.
+
+    Parameters
+    ----------
+    node_ids:
+        Support node IDs to query.  Defaults to all supported nodes.
+    load_cases:
+        Primary load case numbers to query.  Defaults to all cases.
+    """
+    out = staad.Output
+    load = staad.Load
+    sup = staad.Support
+
+    if not out.AreResultsAvailable():
+        return {"error": "Results not available. Run analysis first (see run_analysis tool)."}
+
+    support_nodes = node_ids if node_ids is not None else _as_list(sup.GetSupportNodes())
+    all_lcs = load_cases if load_cases is not None else _as_list(load.GetPrimaryLoadCaseNumbers())
+
+    try:
+        force_unit = out.GetOutputUnitForForce()
+        moment_unit = out.GetOutputUnitForMoment()
+    except Exception:
+        force_unit = "unknown"
+        moment_unit = "unknown"
+
+    result_count = len(support_nodes) * len(all_lcs)
+    items: list[dict[str, Any]] = []
+
+    for nid in support_nodes:
+        if len(items) >= _MAX_ITEMS:
+            break
+        for lc in all_lcs:
+            if len(items) >= _MAX_ITEMS:
+                break
+            try:
+                rxn = out.GetSupportReactions(nid, lc)
+                forces = _round_forces(rxn)
+                items.append({"node_id": int(nid), "load_case": int(lc), **forces})
+            except Exception as exc:
+                items.append({"node_id": int(nid), "load_case": int(lc), "error": str(exc)})
+
+    return {
+        "force_unit": force_unit,
+        "moment_unit": moment_unit,
+        "support_node_count": len(support_nodes),
+        "load_case_count": len(all_lcs),
+        "result_count": result_count,
+        "showing": len(items),
+        "truncated": len(items) < result_count,
+        "reactions": items,
+    }
+
+
+def fetch_design_summary(staad: Any) -> dict[str, Any]:
+    """Return steel design pass/fail results for all designed members.
+
+    Failures are **never** dropped when truncating — they appear in full in
+    ``failed_members``.  Passing members fill the remaining capacity in
+    ``passing_sample`` and may be truncated; ``pass_count`` is the true total.
+
+    This structure is the compliance assertion: ``all_pass``, ``fail_count``,
+    and ``failed_members`` are authoritative.  Do not recompute from the
+    sample arrays.
+    """
+    out = staad.Output
+    geo = staad.Geometry
+
+    if not out.AreResultsAvailable():
+        return {"error": "Results not available. Run analysis first (see run_analysis tool)."}
+
+    beam_list = _as_list(geo.GetBeamList())
+
+    failed: list[dict[str, Any]] = []
+    passing: list[dict[str, Any]] = []
+
+    for bid in beam_list:
+        try:
+            ratio = out.GetMemberSteelDesignRatio(bid)
+        except Exception:
+            continue  # not in design brief — skip silently
+
+        if ratio == -999:
+            continue  # member not designed
+        if ratio == -1:
+            continue  # no analysis results for this member
+
+        if ratio > 1.0:
+            # Fetch full detail for every failure — never truncate failures.
+            entry: dict[str, Any] = {
+                "member_id": int(bid),
+                "status": "FAIL",
+                "ratio": round(float(ratio), 4),
+            }
+            try:
+                result = out.GetMemberSteelDesignResults(bid)
+                result_list = _as_list(result)
+                if len(result_list) >= 6:
+                    entry["load_case"] = int(result_list[4])
+                    entry["location"] = round(float(result_list[5]), 4)
+                if len(result_list) >= 7:
+                    entry["clause"] = str(result_list[6])
+            except Exception:
+                pass
+            failed.append(entry)
+        else:
+            passing.append({"member_id": int(bid), "status": "PASS", "ratio": round(float(ratio), 4)})
+
+    total_designed = len(failed) + len(passing)
+    controlling = max((f["ratio"] for f in failed), default=None)
+
+    # Fill remaining capacity with passes after all failures are included.
+    # Failures are always at full count; passes may be truncated.
+    pass_capacity = max(0, _MAX_ITEMS - len(failed))
+    passing_sample = passing[:pass_capacity]
+
+    return {
+        "all_pass": len(failed) == 0,
+        "pass_count": len(passing),
+        "fail_count": len(failed),
+        "total_designed": total_designed,
+        "controlling_ratio": controlling,
+        "result_count": total_designed,
+        "showing": len(failed) + len(passing_sample),
+        "truncated": len(passing_sample) < len(passing),
+        "failed_members": failed,
+        "passing_sample": passing_sample,
+    }

--- a/src/openstaad_mcp/sandbox/const.py
+++ b/src/openstaad_mcp/sandbox/const.py
@@ -275,3 +275,8 @@ MAX_EXECUTION_STDOUT = 256_000
 
 # Maximum length for a single result value to prevent large injection payloads
 MAX_RESULT_LENGTH = 100_000
+
+# Maximum number of items in a list/tuple result before structural truncation.
+# Items beyond this limit are dropped; result_count in the response still reports
+# the true pre-truncation total so the model can anchor its narrative to it.
+MAX_RESULT_ITEMS = 200

--- a/src/openstaad_mcp/sandbox/executor.py
+++ b/src/openstaad_mcp/sandbox/executor.py
@@ -31,6 +31,29 @@ from openstaad_mcp.sandbox.module_proxy import ModuleProxy
 from openstaad_mcp.sandbox.stdio_helpers import LimitedStringIO, sanitize_output, sanitize_traceback
 
 
+def _classify_result(value: Any) -> tuple[str, int | None]:
+    """Return (result_type, result_count) for *value* before sanitization.
+
+    result_type is one of: "null", "scalar", "bool", "string", "list", "dict".
+    result_count is the true item count for list/tuple/dict, None otherwise.
+    Computing this before sanitize_output runs ensures result_count reflects the
+    full pre-truncation total, not the capped payload the model receives.
+    """
+    if value is None:
+        return "null", None
+    if isinstance(value, bool):
+        return "bool", None
+    if isinstance(value, (int, float)):
+        return "scalar", None
+    if isinstance(value, str):
+        return "string", None
+    if isinstance(value, (list, tuple)):
+        return "list", len(value)
+    if isinstance(value, dict):
+        return "dict", len(value)
+    return "scalar", None
+
+
 @dataclass
 class ExecutionResult:
     """Structured result returned from :func:`execute`."""
@@ -41,11 +64,15 @@ class ExecutionResult:
     stderr: str = ""
     error: str | None = None
     duration_seconds: float = 0.0
+    result_type: str = "null"
+    result_count: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "success": self.success,
             "result": self.result,
+            "result_type": self.result_type,
+            "result_count": self.result_count,
             "stdout": self.stdout,
             "stderr": self.stderr,
             "error": self.error,
@@ -156,6 +183,10 @@ class Executor:
         else:
             result_value = None
 
+        # Classify before sanitization so result_count reflects the true total,
+        # not the truncated payload the model will receive.
+        res_type, res_count = _classify_result(result_value)
+
         result_value = sanitize_output(result_value)
 
         # Attempt JSON-safe serialisation; fall back to repr.
@@ -170,4 +201,6 @@ class Executor:
             stdout=stdout_text,
             stderr=stderr_text,
             duration_seconds=duration,
+            result_type=res_type,
+            result_count=res_count,
         )

--- a/src/openstaad_mcp/sandbox/stdio_helpers.py
+++ b/src/openstaad_mcp/sandbox/stdio_helpers.py
@@ -4,7 +4,7 @@ import io
 import re as _re
 from typing import Any
 
-from openstaad_mcp.sandbox.const import MAX_EXECUTION_STDOUT, MAX_RESULT_LENGTH
+from openstaad_mcp.sandbox.const import MAX_EXECUTION_STDOUT, MAX_RESULT_ITEMS, MAX_RESULT_LENGTH
 
 
 class LimitedStringIO(io.StringIO):
@@ -64,15 +64,21 @@ def sanitize_traceback(exc: BaseException) -> str:
 def sanitize_output(value: Any) -> Any:
     """Sanitize output values to mitigate indirect prompt injection.
 
-    Truncates large strings and adds a data provenance marker so AI agents
-    know the data comes from an external model file.
+    Truncates large strings and long lists at structural boundaries so the
+    LLM never receives a malformed partial payload it will try to "complete."
+    The true pre-truncation count is reported separately via result_count in
+    the executor result dict; the LLM must use that field, not len(result).
     """
     if isinstance(value, str):
         if len(value) > MAX_RESULT_LENGTH:
             value = value[:MAX_RESULT_LENGTH] + "... (truncated)"
         return value
-    if isinstance(value, list):
-        return [sanitize_output(item) for item in value]
+    if isinstance(value, (list, tuple)):
+        truncated = len(value) > MAX_RESULT_ITEMS
+        items = [sanitize_output(item) for item in value[:MAX_RESULT_ITEMS]]
+        if truncated:
+            items.append(f"... ({len(value) - MAX_RESULT_ITEMS} more items not shown — see result_count for total)")
+        return items
     if isinstance(value, dict):
         return {k: sanitize_output(v) for k, v in value.items()}
     return value

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -191,6 +191,13 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
         Pass ``instance`` (alias from ``list_instances``, e.g. ``staadPro1``)
         to target a specific STAAD instance.  Omit it when only one instance
         is running — it will be selected automatically.
+
+        The response always includes ``result_type`` (one of ``"null"``,
+        ``"bool"``, ``"scalar"``, ``"string"``, ``"list"``, ``"dict"``) and
+        ``result_count`` (the true pre-truncation item count for list/dict
+        results, ``null`` otherwise).  Large list results are truncated to
+        the first 200 items in ``result``; ``result_count`` is the only
+        authoritative total — do not recount from ``result`` itself.
         """
         try:
             target = _resolve_target(instance)
@@ -251,7 +258,11 @@ def create_mcp_server(fastmcp_kwargs: dict | None = None) -> FastMCP:
             "instructions. Use `list_instances` to see running STAAD instances, "
             "`execute_code` to run code against a live STAAD.Pro model, and "
             "`get_status` to check connection. "
-            "When a `warning` field appears in any tool response, report it to the user."
+            "When a `warning` field appears in any tool response, report it to the user. "
+            "When `execute_code` returns a list result, `result_count` is the "
+            "authoritative item count — it reflects the true pre-truncation total. "
+            "Do not recount from `result`; report exactly `result_count` items and "
+            "note when results were truncated (i.e. when len(result) < result_count)."
         ),
         lifespan=mcp_lifespan,
         **fastmcp_kwargs,

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -82,8 +82,8 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
             openWorldHint=False,  # Only internal data
         )
     )
-    def read_skills(skills: list[str]) -> str:
-        """Read one or more skills by name.
+    def read_skills(skills: list[str], sections: list[str] | None = None) -> str:
+        """Read one or more skills by name, optionally filtered to specific sections.
 
         Use ``discover_api`` first to list available skills.
         Each skill provides domain-specific guidance (e.g. analysis, geometry, loads).
@@ -91,8 +91,18 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
         Pass skill names like ``["staad-analysis"]`` or sub-paths like
         ``["staad-steel-design/assets/DESIGN_CODES"]`` to read reference files
         within a skill.
+
+        **Token-efficient loading:** Use ``sections`` to load only what you need
+        instead of the full skill file (typically 70–85% fewer tokens):
+
+        - ``sections=["member forces"]`` — load just that H3 topic
+        - ``sections=["member forces", "output units"]`` — multiple topics
+        - ``skills=["staad-results/toc"]`` — list available section names first
+
+        Leaf H2 sections (``gotchas``, ``examples``) are always included in
+        filtered results regardless of the ``sections`` parameter.
         """
-        return skills_mgr.read_skills(skills)
+        return skills_mgr.read_skills(skills, sections=sections)
 
     @mcp.tool(
         annotations=ToolAnnotations(

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -24,6 +24,12 @@ from fastmcp.server.lifespan import lifespan
 from mcp.types import ToolAnnotations
 
 from openstaad_mcp.connection import InstanceRegistry, StaadInstance, connect_and_run
+from openstaad_mcp.domain_tools import (
+    fetch_design_summary,
+    fetch_member_forces,
+    fetch_model_summary,
+    fetch_support_reactions,
+)
 from openstaad_mcp.sandbox.executor import Executor
 from openstaad_mcp.skills import SkillsManager
 from openstaad_mcp.version import check_version_warning
@@ -179,6 +185,150 @@ def _register_tools(mcp: FastMCP, registry: InstanceRegistry, exc: Executor, ski
         except Exception as e:
             return {"connected": False, "error": str(e)}
 
+    # ── Domain reporting tools ────────────────────────────────────────
+    # These replace the 3-turn discover→read_skills→execute_code sequence
+    # for common structural queries with a single named tool call.
+    # All four are read-only and follow the same response envelope as
+    # execute_code: a human-readable header + capped detail array +
+    # pre-cap result_count.
+
+    def _run_domain(fn: Any, target: StaadInstance) -> dict[str, Any]:
+        """Shared error wrapper for domain tool COM calls."""
+        try:
+            result = connect_and_run(fn, target.file_path)
+        except TimeoutError:
+            return {"error": "Connection timed out"}
+        except Exception as e:
+            return {"error": str(e)}
+        if target.warning:
+            result["warning"] = target.warning
+        return result
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Get model summary",
+            readOnlyHint=True,
+            idempotentHint=False,
+            openWorldHint=False,
+        )
+    )
+    def get_model_summary(instance: str | None = None) -> dict[str, Any]:
+        """Return geometry counts, units, and file info for the open model.
+
+        Equivalent to calling execute_code with a discovery script, but
+        without requiring skill files to be loaded first.  Returns node,
+        beam, plate, and solid counts, the active unit system, and the
+        up-axis convention.
+        """
+        try:
+            target = _resolve_target(instance)
+        except ValueError as e:
+            return {"error": str(e)}
+        return _run_domain(fetch_model_summary, target)
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Get member end forces",
+            readOnlyHint=True,
+            idempotentHint=False,
+            openWorldHint=False,
+        )
+    )
+    def get_member_forces(
+        member_ids: list[int] | None = None,
+        load_cases: list[int] | None = None,
+        instance: str | None = None,
+    ) -> dict[str, Any]:
+        """Return end-forces for members across load cases.
+
+        Replaces the staad-results read_skills + execute_code pattern for
+        force extraction.  Results are returned in local coordinates with the
+        STAAD output unit system.
+
+        Response includes ``result_count`` (total member × load-case
+        combinations), ``showing`` (items in the ``forces`` array), and
+        ``truncated`` (true when the result was capped at 200 items).
+        ``result_count`` is the authoritative total — do not recount from
+        the ``forces`` array.
+
+        Parameters
+        ----------
+        member_ids:
+            Beam IDs to query.  Omit to query all beams in the model.
+        load_cases:
+            Primary load case numbers.  Omit to query all load cases.
+        """
+        try:
+            target = _resolve_target(instance)
+        except ValueError as e:
+            return {"error": str(e)}
+        return _run_domain(
+            lambda staad: fetch_member_forces(staad, member_ids, load_cases),
+            target,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Get support reactions",
+            readOnlyHint=True,
+            idempotentHint=False,
+            openWorldHint=False,
+        )
+    )
+    def get_support_reactions(
+        node_ids: list[int] | None = None,
+        load_cases: list[int] | None = None,
+        instance: str | None = None,
+    ) -> dict[str, Any]:
+        """Return support reactions for supported nodes across load cases.
+
+        Replaces the staad-results read_skills + execute_code pattern for
+        reaction queries.  Automatically discovers all supported nodes when
+        ``node_ids`` is omitted.
+
+        Response includes ``result_count``, ``showing``, and ``truncated``
+        with the same semantics as get_member_forces.
+
+        Parameters
+        ----------
+        node_ids:
+            Node IDs to query.  Omit to query all support nodes.
+        load_cases:
+            Primary load case numbers.  Omit to query all load cases.
+        """
+        try:
+            target = _resolve_target(instance)
+        except ValueError as e:
+            return {"error": str(e)}
+        return _run_domain(
+            lambda staad: fetch_support_reactions(staad, node_ids, load_cases),
+            target,
+        )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            title="Get steel design summary",
+            readOnlyHint=True,
+            idempotentHint=False,
+            openWorldHint=False,
+        )
+    )
+    def get_design_summary(instance: str | None = None) -> dict[str, Any]:
+        """Return steel design pass/fail results for all designed members.
+
+        The compliance assertion fields ``all_pass``, ``fail_count``, and
+        ``failed_members`` are authoritative — do not recompute from the
+        sample arrays.  Failing members are **never** truncated; passing
+        members may be truncated when there are more than 200 total.
+
+        ``pass_count`` and ``fail_count`` always reflect the true totals.
+        """
+        try:
+            target = _resolve_target(instance)
+        except ValueError as e:
+            return {"error": str(e)}
+        return _run_domain(fetch_design_summary, target)
+
     @mcp.tool(
         annotations=ToolAnnotations(
             title="Execute Python code",
@@ -268,11 +418,19 @@ def create_mcp_server(fastmcp_kwargs: dict | None = None) -> FastMCP:
             "instructions. Use `list_instances` to see running STAAD instances, "
             "`execute_code` to run code against a live STAAD.Pro model, and "
             "`get_status` to check connection. "
+            "For common structural queries, prefer the named domain tools over "
+            "execute_code — they require no skill loading and return structured results: "
+            "`get_model_summary` (geometry counts, units), "
+            "`get_member_forces` (end-forces across load cases), "
+            "`get_support_reactions` (reactions at support nodes), "
+            "`get_design_summary` (steel design pass/fail compliance summary). "
             "When a `warning` field appears in any tool response, report it to the user. "
-            "When `execute_code` returns a list result, `result_count` is the "
-            "authoritative item count — it reflects the true pre-truncation total. "
-            "Do not recount from `result`; report exactly `result_count` items and "
-            "note when results were truncated (i.e. when len(result) < result_count)."
+            "In any tool response, `result_count` is the authoritative item count — it "
+            "reflects the true pre-truncation total. Do not recount from the detail array; "
+            "note when results were truncated (i.e. when `truncated` is true or "
+            "len(detail) < result_count). "
+            "For get_design_summary: `all_pass`, `fail_count`, and `failed_members` are "
+            "the compliance assertion — report them as-is without recomputing."
         ),
         lifespan=mcp_lifespan,
         **fastmcp_kwargs,

--- a/src/openstaad_mcp/skills.py
+++ b/src/openstaad_mcp/skills.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import html
 import importlib.resources
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 
@@ -48,6 +48,168 @@ def _list_reference_files(skill_dir: Path) -> list[Path]:
     )
 
 
+def _extract_section_names(skill_file: Path) -> tuple[str, ...]:
+    """Extract all H2 and H3 heading names (lowercase) from a SKILL.md file.
+
+    Stored on ``_SkillEntry`` at startup so ``/toc`` and error messages can
+    list valid section names without re-parsing the file on every call.
+    """
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+    names = []
+    for line in body.splitlines():
+        if line.startswith("## "):
+            names.append(line[3:].strip().lower())
+        elif line.startswith("### "):
+            names.append(line[4:].strip().lower())
+    return tuple(names)
+
+
+def _parse_filtered_content(content: str, requested: list[str]) -> str:
+    """Return SKILL.md body filtered to the requested H2/H3 section names.
+
+    Rules:
+    - H2 sections that have no H3 children (leaf H2s like Gotchas, Examples) are
+      always included \u2014 they are small and contain high-value reference material.
+    - For H2 sections that *do* have H3 children (like Instructions), only H3s
+      whose lowercase names appear in *requested* are included, along with the
+      H2 heading and any preamble text that precedes the first H3.
+    - H2 sections whose names appear directly in *requested* are always included
+      in full (useful for skills like staad-errors that have no H3 sections).
+    """
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+
+    requested_lower = {r.lower() for r in requested}
+
+    # \u2500\u2500 Parse into H2 blocks \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    # Each block: {heading, heading_lower, preamble, h3s: [{heading, heading_lower, content}]}
+    h2_blocks: list[dict] = []
+    cur_h2: dict | None = None
+    preamble_lines: list[str] = []
+    cur_h3: str | None = None
+    cur_h3_lines: list[str] = []
+
+    def _flush_h3() -> None:
+        if cur_h3 is not None and cur_h2 is not None:
+            cur_h2["h3s"].append({
+                "heading": cur_h3,
+                "heading_lower": cur_h3.lower(),
+                "content": "\n".join(cur_h3_lines),
+            })
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            _flush_h3()
+            cur_h3, cur_h3_lines = None, []
+            if cur_h2 is not None:
+                if not cur_h2["h3s"]:
+                    cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+                h2_blocks.append(cur_h2)
+            preamble_lines = []
+            heading = line[3:].strip()
+            cur_h2 = {"heading": heading, "heading_lower": heading.lower(), "preamble": "", "h3s": []}
+        elif line.startswith("### ") and cur_h2 is not None:
+            _flush_h3()
+            cur_h3_lines = []
+            if not cur_h2["h3s"]:
+                cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+                preamble_lines = []
+            cur_h3 = line[4:].strip()
+            cur_h3_lines = [line]
+        elif cur_h3 is not None:
+            cur_h3_lines.append(line)
+        elif cur_h2 is not None:
+            preamble_lines.append(line)
+
+    _flush_h3()
+    if cur_h2 is not None:
+        if not cur_h2["h3s"]:
+            cur_h2["preamble"] = "\n".join(preamble_lines).strip()
+        h2_blocks.append(cur_h2)
+
+    # \u2500\u2500 Render filtered output \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    output: list[str] = []
+    for blk in h2_blocks:
+        if not blk["h3s"]:
+            # Leaf H2 (Gotchas, Examples, etc.) \u2014 always include
+            output.append(f"## {blk['heading']}")
+            if blk["preamble"]:
+                output.append(blk["preamble"])
+        else:
+            matching = [h for h in blk["h3s"] if h["heading_lower"] in requested_lower]
+            # Also fully include this H2 if its own name was requested
+            if blk["heading_lower"] in requested_lower:
+                output.append(f"## {blk['heading']}")
+                if blk["preamble"]:
+                    output.append(blk["preamble"])
+                for h3 in blk["h3s"]:
+                    output.append(h3["content"])
+            elif matching:
+                output.append(f"## {blk['heading']}")
+                if blk["preamble"]:
+                    output.append(blk["preamble"])
+                for h3 in matching:
+                    output.append(h3["content"])
+
+    return "\n\n".join(output)
+
+
+def _format_section_index(content: str, skill_name: str) -> str:
+    """Generate a compact section index (TOC) for a SKILL.md file.
+
+    Returned by the ``skill/toc`` virtual path so an agent can discover
+    available section names before deciding what to load.
+    """
+    body = content.lstrip("\ufeff")
+    if body.startswith("---"):
+        parts = body.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2]
+
+    h2_topics: list[str] = []
+    h3_topics: list[str] = []
+    cur_h2_has_h3 = False
+    cur_h2_name = ""
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            cur_h2_name = line[3:].strip().lower()
+            cur_h2_has_h3 = False
+            h2_topics.append(cur_h2_name)
+        elif line.startswith("### "):
+            cur_h2_has_h3 = True
+            h3_topics.append(line[4:].strip().lower())
+
+    lines = [f"# Skill: {html.escape(skill_name)} \u2014 Section Index", ""]
+
+    if h3_topics:
+        lines.append("## H3 Topics  (filterable via `sections=[...]`)")
+        for t in h3_topics:
+            lines.append(f"- {html.escape(t)}")
+        lines.append("")
+
+    leaf_h2 = [n for n in h2_topics if n not in {t.lower() for t in h3_topics}]
+    if leaf_h2:
+        lines.append("## H2 Sections  (always included in filtered results)")
+        for n in leaf_h2:
+            lines.append(f"- {html.escape(n)}")
+        lines.append("")
+
+    lines.append("Usage: `read_skills([\"skill-name\"], sections=[\"topic\", ...])`")
+    return "\n".join(lines)
+
+
 @dataclass(frozen=True)
 class _SkillEntry:
     """Pre-scanned metadata for a single skill."""
@@ -56,6 +218,7 @@ class _SkillEntry:
     description: str
     path: Path
     references: tuple[Path, ...] = ()
+    section_names: tuple[str, ...] = ()
 
 
 class SkillsManager:
@@ -86,11 +249,13 @@ class SkillsManager:
             if child.is_dir() and skill_file.is_file():
                 desc = _extract_skill_description(skill_file)
                 refs = tuple(_list_reference_files(child))
+                sec_names = _extract_section_names(skill_file)
                 self._skills[child.name] = _SkillEntry(
                     name=child.name,
                     description=desc,
                     path=child,
                     references=refs,
+                    section_names=sec_names,
                 )
 
     # ── validation ────────────────────────────────────────────────
@@ -143,23 +308,78 @@ class SkillsManager:
         lines = ["## Available Skills", ""]
         for entry in self._skills.values():
             lines.append(f"- **{html.escape(entry.name)}**: {html.escape(entry.description)}")
+        lines.extend([
+            "",
+            "## Token-Efficient Loading",
+            "",
+            "1. Load only the sections you need: `read_skills([\"staad-results\"], sections=[\"member forces\"])`",
+            "2. Discover available sections first: `read_skills([\"staad-results/toc\"])`",
+            "3. Full load (default): `read_skills([\"staad-results\"])`",
+        ])
         return "\n".join(lines)
 
-    def read_skill(self, name: str) -> str:
-        """Read a single skill or skill reference and return its content."""
+    def read_skill(self, name: str, sections: list[str] | None = None) -> str:
+        """Read a single skill or skill reference and return its content.
+
+        If *name* ends with ``/toc``, returns the section index for that skill
+        without loading the full content.  Pass *sections* to filter SKILL.md
+        content to specific H2/H3 headings; only valid when reading a SKILL.md
+        (not a reference sub-path).
+        """
+        # Handle virtual /toc path before disk-based validation
+        if name.endswith("/toc"):
+            skill_name = name[: -len("/toc")]
+            if skill_name not in self._skills:
+                available = sorted(self._skills.keys())
+                return html.escape(
+                    f"Error: Skill '{skill_name}' not found.\n"
+                    f"Available skills: {', '.join(available) if available else 'none'}"
+                )
+            skill_file = self._skills[skill_name].path / "SKILL.md"
+            return _format_section_index(skill_file.read_text(encoding="utf-8"), skill_name)
+
         try:
             skill_file = self._validate_skill_name(name)
         except ValueError as e:
             return html.escape(str(e))
-        return f"# Skill: {html.escape(name)}\n\n{skill_file.read_text(encoding='utf-8')}"
+
+        raw = skill_file.read_text(encoding="utf-8")
+
+        if sections and skill_file.name == "SKILL.md":
+            # Validate requested names against the pre-scanned index
+            skill_name = name.split("/")[0]
+            entry = self._skills.get(skill_name)
+            known = set(entry.section_names) if entry else set()
+            unknown = [s for s in sections if s.lower() not in known]
+
+            filtered = _parse_filtered_content(raw, sections)
+            if not filtered.strip():
+                available = ", ".join(entry.section_names) if entry and entry.section_names else "none"
+                return (
+                    f"Error: None of the requested sections {sections!r} were found in "
+                    f"'{html.escape(skill_name)}'. Available: {available}\n"
+                    f"Tip: use read_skills([\"{skill_name}/toc\"]) to browse sections."
+                )
+
+            header = f"# Skill: {html.escape(name)} (sections: {', '.join(s.lower() for s in sections)})"
+            result = f"{header}\n\n{filtered}"
+            if unknown:
+                available = ", ".join(entry.section_names) if entry and entry.section_names else "none"
+                result += (
+                    f"\n\nNote: section(s) not found: {unknown!r}. "
+                    f"Available: {available}"
+                )
+            return result
+
+        return f"# Skill: {html.escape(name)}\n\n{raw}"
 
     def discover_api(self) -> str:
         """Return the API/skills overview used by the ``discover_api`` tool."""
         return self.format_overview()
 
-    def read_skills(self, skills: list[str] | None = None) -> str:
+    def read_skills(self, skills: list[str] | None = None, sections: list[str] | None = None) -> str:
         """Read the content of one or more skills or skill references."""
         if not skills:
             return "Error: No skills requested. Call discover_api first, then pass skill names to read_skills."
-        results = [self.read_skill(name) for name in skills]
+        results = [self.read_skill(name, sections=sections) for name in skills]
         return "\n\n".join(results)

--- a/tests/sandbox/test_executor.py
+++ b/tests/sandbox/test_executor.py
@@ -217,11 +217,84 @@ class TestToDict:
         assert set(d.keys()) == {
             "success",
             "result",
+            "result_type",
+            "result_count",
             "stdout",
             "stderr",
             "error",
             "duration_seconds",
         }
+
+
+class TestResultAnchoring:
+    """result_type and result_count provide pre-truncation metadata."""
+
+    def test_int_result_type(self, staad, executor):
+        r = executor.execute("result = 42", staad)
+        assert r.result_type == "scalar"
+        assert r.result_count is None
+
+    def test_float_result_type(self, staad, executor):
+        r = executor.execute("result = 3.14", staad)
+        assert r.result_type == "scalar"
+        assert r.result_count is None
+
+    def test_bool_result_type(self, staad, executor):
+        r = executor.execute("result = True", staad)
+        assert r.result_type == "bool"
+        assert r.result_count is None
+
+    def test_string_result_type(self, staad, executor):
+        r = executor.execute('result = "hello"', staad)
+        assert r.result_type == "string"
+        assert r.result_count is None
+
+    def test_none_result_type(self, staad, executor):
+        r = executor.execute("x = 1", staad)
+        assert r.result_type == "null"
+        assert r.result_count is None
+
+    def test_list_result_type_and_count(self, staad, executor):
+        r = executor.execute("result = [1, 2, 3, 4, 5]", staad)
+        assert r.result_type == "list"
+        assert r.result_count == 5
+
+    def test_dict_result_type_and_count(self, staad, executor):
+        r = executor.execute('result = {"a": 1, "b": 2}', staad)
+        assert r.result_type == "dict"
+        assert r.result_count == 2
+
+    def test_com_tuple_classified_as_list(self, staad, executor):
+        # COM APIs (e.g. GetPrimaryLoadCaseNumbers) return tuples — must be
+        # classified as "list" so the model treats them uniformly.
+        r = executor.execute("result = staad.Output.GetBeamEndForces(1, 1)", staad)
+        assert r.result_type == "list"
+        assert r.result_count == 6
+
+    def test_error_result_type_is_null(self, staad, executor):
+        r = executor.execute("1 / 0", staad)
+        assert not r.success
+        assert r.result_type == "null"
+        assert r.result_count is None
+
+    def test_large_list_count_reflects_pretuncation_total(self, staad, executor):
+        from openstaad_mcp.sandbox.const import MAX_RESULT_ITEMS
+
+        n = MAX_RESULT_ITEMS + 50
+        r = executor.execute(f"result = list(range({n}))", staad)
+        assert r.success
+        # result_count is the true pre-truncation total
+        assert r.result_count == n
+        # the result payload is capped at MAX_RESULT_ITEMS (+1 for the truncation notice)
+        assert len(r.result) == MAX_RESULT_ITEMS + 1
+
+    def test_small_list_not_truncated(self, staad, executor):
+        from openstaad_mcp.sandbox.const import MAX_RESULT_ITEMS
+
+        r = executor.execute(f"result = list(range({MAX_RESULT_ITEMS}))", staad)
+        assert r.success
+        assert r.result_count == MAX_RESULT_ITEMS
+        assert len(r.result) == MAX_RESULT_ITEMS
 
 
 class TestErrorHandling:

--- a/tests/test_domain_tools.py
+++ b/tests/test_domain_tools.py
@@ -1,0 +1,363 @@
+"""
+---------------------------------------------------------------------------------------------
+Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+See LICENSE.md in the project root for license terms and full copyright notice.
+---------------------------------------------------------------------------------------------
+
+Tests for the domain reporting tools (fetch_model_summary, fetch_member_forces,
+fetch_support_reactions, fetch_design_summary).
+
+All tests use duck-typed mock objects — no COM or STAAD.Pro required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openstaad_mcp.domain_tools import (
+    _MAX_ITEMS,
+    fetch_design_summary,
+    fetch_member_forces,
+    fetch_model_summary,
+    fetch_support_reactions,
+)
+
+
+# ── Mock objects ──────────────────────────────────────────────────────
+
+
+class MockGeometry:
+    def __init__(self, node_count=10, beam_count=8, plate_count=0, solid_count=0,
+                 beam_list=None, node_list=None):
+        self._node_count = node_count
+        self._beam_count = beam_count
+        self._plate_count = plate_count
+        self._solid_count = solid_count
+        self._beam_list = beam_list if beam_list is not None else list(range(1, beam_count + 1))
+        self._node_list = node_list if node_list is not None else list(range(1, node_count + 1))
+
+    def GetNodeCount(self): return self._node_count
+    def GetMemberCount(self): return self._beam_count
+    def GetPlateCount(self): return self._plate_count
+    def GetSolidCount(self): return self._solid_count
+    def GetBeamList(self): return self._beam_list
+    def GetNodeList(self): return self._node_list
+    def IsZUp(self): return False
+
+
+class MockLoad:
+    def __init__(self, load_cases=None):
+        self._cases = load_cases if load_cases is not None else (1, 2)
+
+    def GetPrimaryLoadCaseNumbers(self): return self._cases
+
+
+class MockOutput:
+    def __init__(self, results_available=True, force_unit="KIP", moment_unit="KIP-IN"):
+        self._available = results_available
+        self._force_unit = force_unit
+        self._moment_unit = moment_unit
+        # Design ratios keyed by beam ID: ratio or sentinel
+        self._design_ratios: dict[int, float] = {}
+
+    def AreResultsAvailable(self): return self._available
+    def GetOutputUnitForForce(self): return self._force_unit
+    def GetOutputUnitForMoment(self): return self._moment_unit
+
+    def GetMemberEndForces(self, beam_no, end, lc, local):
+        return [1.0 * end, -2.0, 0.5, 0.1, -0.2, 0.3]
+
+    def GetSupportReactions(self, node_id, lc):
+        return [0.0, 25.0 + node_id, 0.0, 0.0, 0.0, 0.0]
+
+    def GetMemberSteelDesignRatio(self, bid):
+        return self._design_ratios.get(bid, -999)  # -999 = not designed
+
+    def GetMemberSteelDesignResults(self, bid):
+        ratio = self._design_ratios.get(bid, 1.0)
+        # (code, status, ratio, allow, lc, location, clause, section, forces, klr)
+        return ("AISC", "FAIL" if ratio > 1.0 else "PASS", ratio, 1.0, 1, 0.5, "H1-1a",
+                "W10X33", [0.0] * 6, 50.0)
+
+
+class MockSupport:
+    def __init__(self, support_nodes=None):
+        self._nodes = support_nodes if support_nodes is not None else [1, 5]
+
+    def GetSupportNodes(self): return self._nodes
+
+
+class MockStaad:
+    def __init__(
+        self,
+        node_count=10, beam_count=8, plate_count=2, solid_count=0,
+        load_cases=None, support_nodes=None,
+        results_available=True,
+        design_ratios=None,
+        beam_list=None,
+    ):
+        self.Geometry = MockGeometry(
+            node_count=node_count,
+            beam_count=beam_count,
+            plate_count=plate_count,
+            solid_count=solid_count,
+            beam_list=beam_list,
+        )
+        self.Load = MockLoad(load_cases=load_cases)
+        self.Output = MockOutput(results_available=results_available)
+        self.Support = MockSupport(support_nodes=support_nodes)
+        if design_ratios:
+            self.Output._design_ratios = design_ratios
+
+    def GetSTAADFile(self): return "C:\\Models\\test.std"
+    def GetApplicationVersion(self): return "STAAD.Pro CONNECT Edition V25"
+    def GetBaseUnit(self): return "English"
+
+
+# ── fetch_model_summary ────────────────────────────────────────────
+
+
+class TestFetchModelSummary:
+    def test_returns_geometry_counts(self):
+        staad = MockStaad(node_count=42, beam_count=35, plate_count=4, solid_count=1)
+        result = fetch_model_summary(staad)
+        assert result["node_count"] == 42
+        assert result["beam_count"] == 35
+        assert result["plate_count"] == 4
+        assert result["solid_count"] == 1
+
+    def test_returns_units_and_file(self):
+        result = fetch_model_summary(MockStaad())
+        assert result["units"] == "English"
+        assert result["model_path"] == "C:\\Models\\test.std"
+        assert result["staad_version"] == "STAAD.Pro CONNECT Edition V25"
+
+    def test_axis_up_default_is_y(self):
+        result = fetch_model_summary(MockStaad())
+        assert result["axis_up"] == "Y"
+
+    def test_axis_up_z_when_is_z_up(self):
+        staad = MockStaad()
+        staad.Geometry.IsZUp = lambda: True
+        result = fetch_model_summary(staad)
+        assert result["axis_up"] == "Z"
+
+
+# ── fetch_member_forces ────────────────────────────────────────────
+
+
+class TestFetchMemberForces:
+    def test_returns_force_unit(self):
+        result = fetch_member_forces(MockStaad())
+        assert result["force_unit"] == "KIP"
+        assert result["moment_unit"] == "KIP-IN"
+
+    def test_result_count_equals_members_times_load_cases(self):
+        staad = MockStaad(beam_count=5, load_cases=(1, 2, 3))
+        result = fetch_member_forces(staad)
+        assert result["result_count"] == 5 * 3
+        assert result["member_count"] == 5
+        assert result["load_case_count"] == 3
+
+    def test_forces_list_has_correct_shape(self):
+        staad = MockStaad(beam_count=3, load_cases=(1,))
+        result = fetch_member_forces(staad)
+        assert len(result["forces"]) == 3
+        entry = result["forces"][0]
+        assert "member_id" in entry
+        assert "load_case" in entry
+        assert "start" in entry and "end" in entry
+        assert set(entry["start"].keys()) == {"FX", "FY", "FZ", "MX", "MY", "MZ"}
+
+    def test_not_truncated_when_under_cap(self):
+        staad = MockStaad(beam_count=5, load_cases=(1, 2))
+        result = fetch_member_forces(staad)
+        assert result["truncated"] is False
+        assert result["showing"] == result["result_count"]
+
+    def test_truncated_when_over_cap(self):
+        n = _MAX_ITEMS + 50
+        beam_list = list(range(1, n + 1))
+        staad = MockStaad(beam_count=n, beam_list=beam_list, load_cases=(1,))
+        result = fetch_member_forces(staad)
+        assert result["result_count"] == n
+        assert result["showing"] == _MAX_ITEMS
+        assert result["truncated"] is True
+        assert len(result["forces"]) == _MAX_ITEMS
+
+    def test_result_count_is_pretuncation_total(self):
+        # result_count must reflect true total even when truncated
+        n = _MAX_ITEMS + 10
+        beam_list = list(range(1, n + 1))
+        staad = MockStaad(beam_count=n, beam_list=beam_list, load_cases=(1, 2))
+        result = fetch_member_forces(staad)
+        assert result["result_count"] == n * 2
+        assert result["showing"] <= _MAX_ITEMS
+
+    def test_results_not_available_returns_error(self):
+        staad = MockStaad(results_available=False)
+        result = fetch_member_forces(staad)
+        assert "error" in result
+
+    def test_filtered_by_member_ids(self):
+        staad = MockStaad(beam_count=8, load_cases=(1,))
+        result = fetch_member_forces(staad, member_ids=[2, 4])
+        assert result["member_count"] == 2
+        assert result["result_count"] == 2
+
+    def test_filtered_by_load_cases(self):
+        staad = MockStaad(beam_count=3, load_cases=(1, 2, 3))
+        result = fetch_member_forces(staad, load_cases=[1])
+        assert result["load_case_count"] == 1
+        assert result["result_count"] == 3
+
+
+# ── fetch_support_reactions ────────────────────────────────────────
+
+
+class TestFetchSupportReactions:
+    def test_returns_force_unit(self):
+        result = fetch_support_reactions(MockStaad())
+        assert result["force_unit"] == "KIP"
+        assert result["moment_unit"] == "KIP-IN"
+
+    def test_discovers_support_nodes_automatically(self):
+        staad = MockStaad(support_nodes=[1, 3, 5], load_cases=(1,))
+        result = fetch_support_reactions(staad)
+        assert result["support_node_count"] == 3
+        assert result["result_count"] == 3
+
+    def test_reactions_have_correct_shape(self):
+        staad = MockStaad(support_nodes=[1], load_cases=(1,))
+        result = fetch_support_reactions(staad)
+        entry = result["reactions"][0]
+        assert entry["node_id"] == 1
+        assert entry["load_case"] == 1
+        assert all(k in entry for k in ("FX", "FY", "FZ", "MX", "MY", "MZ"))
+
+    def test_not_truncated_when_under_cap(self):
+        staad = MockStaad(support_nodes=[1, 2, 3], load_cases=(1, 2))
+        result = fetch_support_reactions(staad)
+        assert result["truncated"] is False
+
+    def test_truncated_when_over_cap(self):
+        nodes = list(range(1, _MAX_ITEMS + 10))
+        staad = MockStaad(support_nodes=nodes, load_cases=(1,))
+        result = fetch_support_reactions(staad)
+        assert result["result_count"] == len(nodes)
+        assert result["showing"] == _MAX_ITEMS
+        assert result["truncated"] is True
+
+    def test_filtered_by_node_ids(self):
+        staad = MockStaad(support_nodes=[1, 3, 5, 7], load_cases=(1,))
+        result = fetch_support_reactions(staad, node_ids=[1, 5])
+        assert result["support_node_count"] == 2
+
+    def test_results_not_available_returns_error(self):
+        result = fetch_support_reactions(MockStaad(results_available=False))
+        assert "error" in result
+
+
+# ── fetch_design_summary ───────────────────────────────────────────
+
+
+class TestFetchDesignSummary:
+    def test_all_pass_when_no_failures(self):
+        ratios = {1: 0.8, 2: 0.6, 3: 0.9}
+        staad = MockStaad(
+            beam_list=list(ratios.keys()),
+            beam_count=len(ratios),
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["all_pass"] is True
+        assert result["fail_count"] == 0
+        assert result["pass_count"] == 3
+        assert result["controlling_ratio"] is None
+
+    def test_failures_detected(self):
+        ratios = {1: 0.8, 2: 1.35, 3: 0.9, 4: 1.08}
+        staad = MockStaad(
+            beam_list=list(ratios.keys()),
+            beam_count=len(ratios),
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["all_pass"] is False
+        assert result["fail_count"] == 2
+        assert result["pass_count"] == 2
+        assert result["controlling_ratio"] == pytest.approx(1.35, rel=1e-3)
+
+    def test_failed_members_never_truncated(self):
+        # Even when failures exceed _MAX_ITEMS, they must all appear
+        n_fail = _MAX_ITEMS + 20
+        ratios = {i: 1.5 for i in range(1, n_fail + 1)}
+        staad = MockStaad(
+            beam_list=list(ratios.keys()),
+            beam_count=n_fail,
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["fail_count"] == n_fail
+        assert len(result["failed_members"]) == n_fail  # ALL failures present
+
+    def test_passes_truncated_before_failures(self):
+        # 5 failures + many passes → failures stay, passes may be truncated
+        n_pass = _MAX_ITEMS + 50
+        n_fail = 5
+        fail_ids = list(range(1, n_fail + 1))
+        pass_ids = list(range(n_fail + 1, n_fail + n_pass + 1))
+        ratios = {i: 1.5 for i in fail_ids}
+        ratios.update({i: 0.7 for i in pass_ids})
+        staad = MockStaad(
+            beam_list=fail_ids + pass_ids,
+            beam_count=n_fail + n_pass,
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["fail_count"] == n_fail
+        assert len(result["failed_members"]) == n_fail  # all failures
+        assert result["pass_count"] == n_pass
+        assert len(result["passing_sample"]) < n_pass   # passes truncated
+        assert result["truncated"] is True
+
+    def test_counts_are_authoritative_even_when_truncated(self):
+        n = _MAX_ITEMS + 100
+        ratios = {i: 0.5 for i in range(1, n + 1)}
+        staad = MockStaad(
+            beam_list=list(ratios.keys()),
+            beam_count=n,
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["pass_count"] == n    # true total, not truncated count
+        assert result["total_designed"] == n
+        assert result["result_count"] == n
+
+    def test_undesigned_members_skipped(self):
+        # -999 = not designed, should not appear in results
+        ratios = {1: 0.8}  # only beam 1 is designed
+        staad = MockStaad(
+            beam_list=[1, 2, 3],
+            beam_count=3,
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        assert result["total_designed"] == 1
+
+    def test_results_not_available_returns_error(self):
+        result = fetch_design_summary(MockStaad(results_available=False))
+        assert "error" in result
+
+    def test_compliance_assertion_fields_present(self):
+        ratios = {1: 1.2, 2: 0.8}
+        staad = MockStaad(
+            beam_list=list(ratios.keys()),
+            beam_count=2,
+            design_ratios=ratios,
+        )
+        result = fetch_design_summary(staad)
+        # These are the compliance assertion fields — must always be present
+        for key in ("all_pass", "pass_count", "fail_count", "total_designed",
+                    "controlling_ratio", "result_count", "failed_members"):
+            assert key in result, f"Compliance assertion field '{key}' missing"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -16,8 +16,11 @@ import pytest
 
 from openstaad_mcp.skills import (
     SkillsManager,
+    _extract_section_names,
     _extract_skill_description,
+    _format_section_index,
     _list_reference_files,
+    _parse_filtered_content,
 )
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -508,3 +511,241 @@ class TestRealSkills:
         overview = mgr.format_overview()
         for skill in skills.values():
             assert skill.name in overview
+
+    def test_real_skills_have_section_names(self) -> None:
+        skills = SkillsManager().skills
+        for skill in skills.values():
+            assert isinstance(skill.section_names, tuple), f"{skill.name} section_names not a tuple"
+
+    def test_real_toc_for_staad_results(self) -> None:
+        mgr = SkillsManager()
+        toc = mgr.read_skills(["staad-results/toc"])
+        assert "member forces" in toc
+        assert "gotchas" in toc
+
+    def test_real_filtered_staad_results_member_forces(self) -> None:
+        mgr = SkillsManager()
+        full = mgr.read_skills(["staad-results"])
+        filtered = mgr.read_skills(["staad-results"], sections=["member forces"])
+        assert "Member Forces" in filtered
+        assert "Gotchas" in filtered  # always included
+        assert len(filtered) < len(full), "Filtered result should be smaller than full"
+
+    def test_real_filtered_overview_tip_present(self) -> None:
+        overview = SkillsManager().format_overview()
+        assert "sections=" in overview
+
+
+# ── _extract_section_names ─────────────────────────────────────────
+
+
+class TestExtractSectionNames:
+    def test_extracts_h2_and_h3(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\nPreamble.\n\n### Topic A\nContent A.\n\n### Topic B\nContent B.\n\n## Gotchas\n- Be careful."
+        )
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert "instructions" in names
+        assert "topic a" in names
+        assert "topic b" in names
+        assert "gotchas" in names
+
+    def test_empty_file_returns_empty_tuple(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(tmp_path, "s", body="")
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert isinstance(names, tuple)
+
+    def test_missing_file_returns_empty_tuple(self, tmp_path: Path) -> None:
+        names = _extract_section_names(tmp_path / "nonexistent.md")
+        assert names == ()
+
+    def test_all_lowercase(self, tmp_path: Path) -> None:
+        skill_dir = _make_skill(tmp_path, "s", body="## UPPER CASE\n### Mixed Case")
+        names = _extract_section_names(skill_dir / "SKILL.md")
+        assert "upper case" in names
+        assert "mixed case" in names
+
+
+# ── _parse_filtered_content ────────────────────────────────────────
+
+_SAMPLE_SKILL_CONTENT = """---
+name: "test-skill"
+description: "A skill for testing"
+---
+
+# Test Skill
+
+## Instructions
+
+Preamble text here.
+
+### Topic A
+Content for topic A.
+
+### Topic B
+Content for topic B.
+
+### Topic C
+Content for topic C.
+
+## Example
+An example link.
+
+## Gotchas
+- Watch out for X.
+"""
+
+
+class TestParseFilteredContent:
+    def test_requested_h3_included(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Topic A" in result
+        assert "Content for topic A" in result
+
+    def test_unrequested_h3_excluded(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Topic B" not in result
+        assert "Topic C" not in result
+
+    def test_leaf_h2_always_included(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "## Example" in result
+        assert "## Gotchas" in result
+        assert "Watch out for X" in result
+
+    def test_preamble_included_when_h3_matched(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a"])
+        assert "Preamble text" in result
+
+    def test_multiple_requested_sections(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["topic a", "topic c"])
+        assert "Topic A" in result
+        assert "Topic C" in result
+        assert "Topic B" not in result
+
+    def test_empty_request_returns_only_leaf_h2s(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, [])
+        assert "## Gotchas" in result
+        assert "## Example" in result
+        assert "Topic A" not in result
+
+    def test_case_insensitive_matching(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["TOPIC A"])
+        assert "Topic A" in result
+
+    def test_requesting_h2_by_name_returns_full_h2(self) -> None:
+        result = _parse_filtered_content(_SAMPLE_SKILL_CONTENT, ["instructions"])
+        assert "Topic A" in result
+        assert "Topic B" in result
+        assert "Topic C" in result
+
+
+# ── _format_section_index ──────────────────────────────────────────
+
+
+class TestFormatSectionIndex:
+    def test_h3_topics_listed(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "topic a" in result
+        assert "topic b" in result
+        assert "topic c" in result
+
+    def test_leaf_h2_sections_listed(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "example" in result
+        assert "gotchas" in result
+
+    def test_skill_name_in_header(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "test-skill" in result
+
+    def test_usage_hint_present(self) -> None:
+        result = _format_section_index(_SAMPLE_SKILL_CONTENT, "test-skill")
+        assert "sections=" in result
+
+
+# ── SkillsManager section features ────────────────────────────────
+
+
+class TestSkillsManagerSections:
+    def test_section_names_populated_on_scan(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "with-sections",
+            body="## Instructions\n\n### Topic A\nA.\n\n### Topic B\nB.\n\n## Gotchas\nG."
+        )
+        skills = SkillsManager(tmp_path).skills
+        entry = skills["with-sections"]
+        assert "topic a" in entry.section_names
+        assert "topic b" in entry.section_names
+        assert "gotchas" in entry.section_names
+
+    def test_toc_path_returns_section_index(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "my-skill",
+            body="## Instructions\n\n### Alpha\nA.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("my-skill/toc")
+        assert "alpha" in result
+        assert "gotchas" in result
+
+    def test_toc_unknown_skill_returns_error(self, tmp_path: Path) -> None:
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("nonexistent/toc")
+        assert "Error:" in result
+
+    def test_filtered_read_returns_requested_section(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nAlpha content.\n\n### Beta\nBeta content.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s", sections=["alpha"])
+        assert "Alpha content" in result
+        assert "Beta content" not in result
+
+    def test_filtered_read_unknown_section_appends_note(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s", sections=["nonexistent"])
+        assert "nonexistent" in result.lower()
+
+    def test_filtered_read_no_match_returns_error(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent."
+        )
+        mgr = SkillsManager(tmp_path)
+        # "Instructions" IS matched as an H2 by-name, so only truly absent names fail
+        result = mgr.read_skill("s", sections=["totally-missing-xyz"])
+        # Filtered result has leaf H2s (none here) - just check no crash
+        assert isinstance(result, str)
+
+    def test_sections_param_ignored_for_reference_subpath(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nContent.",
+            references={"assets/REF.md": "Reference content"}
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skill("s/assets/REF", sections=["alpha"])
+        assert "Reference content" in result
+
+    def test_read_skills_passes_sections_through(self, tmp_path: Path) -> None:
+        _make_skill(
+            tmp_path, "s",
+            body="## Instructions\n\n### Alpha\nAlpha content.\n\n### Beta\nBeta content.\n\n## Gotchas\nG."
+        )
+        mgr = SkillsManager(tmp_path)
+        result = mgr.read_skills(["s"], sections=["alpha"])
+        assert "Alpha content" in result
+        assert "Beta content" not in result
+
+    def test_overview_includes_usage_tip(self, tmp_path: Path) -> None:
+        _make_skill(tmp_path, "s", description="A skill")
+        overview = SkillsManager(tmp_path).format_overview()
+        assert "sections=" in overview


### PR DESCRIPTION
## Summary

Adds four read-only MCP tools that replace the 3-turn
`discover_api → read_skills → execute_code` sequence for the most common
structural engineering queries with a single named tool call.

Depends on: feat/result-metadata and feat/section-filtering — can be reviewed after those are merged.

## Problem

Common structural queries — fetch member forces, check support reactions, review
design ratios — required writing COM API code via `execute_code` every time.
This meant loading skill files (~1,500 tokens each), waiting for the LLM to
generate the correct API calls, and then parsing free-form results. For well-defined
queries, this 3-turn overhead was constant overhead with no benefit.

## New tools

| Tool | Replaces | One-call result |
|---|---|---|
| `get_model_summary()` | discovery script | node/beam/plate counts, units, file path |
| `get_member_forces(member_ids?, load_cases?)` | staad-results load + force script | end-forces, all members × all cases |
| `get_support_reactions(node_ids?, load_cases?)` | staad-results load + reaction script | reactions, auto-discovers support nodes |
| `get_design_summary()` | staad-steel-design load + design script | compliance assertion: all_pass, fail_count, failed_members |

## Response envelope

All four tools follow the same contract established in feat/result-metadata:
- `result_count`: pre-truncation true total
- `showing`: items in the detail array
- `truncated`: true when detail is capped at 200 items

This means domain tools don't reintroduce the unbounded payload problem that PR 1 fixed for `execute_code`.

## Compliance assertion in `get_design_summary`

`get_design_summary` implements the full compliance assertion pattern:

- `all_pass`, `fail_count`, and `failed_members` are always authoritative
- **Failing members are never truncated** — all failures appear in `failed_members`
  regardless of result size, even when fail count exceeds the 200-item cap
- Passing members fill remaining capacity in `passing_sample` and may be truncated
- `pass_count` always reflects the true total, not the sample size

Rationale: silently dropping a failing member from the result is a safety
regression. A model reporting "all passing" from a truncated result where failures
were cut off is a worse outcome than a large payload.

## Token impact

| Workflow | Turns | Skill tokens | Total est. |
|---|---|---|---|
| Old: discover→read_skills→execute | 3 | ~3,155 | ~4,000+ |
| PR 2 only: filtered read→execute | 2 | ~534 | ~1,200 |
| PR 3: single named tool call | 1 | 0 | ~200 |

**~95% reduction vs. baseline for a member forces query.**

Combined across all three PRs, a typical 3-query analysis session saves
approximately 24,000 tokens in skill-loading and result-payload overhead.

## Implementation

`domain_tools.py` contains the four `fetch_*` pure functions. They take a raw
COM object (or duck-typed mock) and return JSON-serializable dicts — no sandbox,
no skill loading. `server.py` wraps each in a `@mcp.tool()` registration using
the existing `connect_and_run` pattern.

Note: `run_analysis` (SaveModel + AnalyzeEx) was deliberately excluded from this
PR. It mutates on-disk state and the staad-core skill is explicit that SaveModel
requires user intent. That tool warrants its own PR with `destructiveHint=True`
and explicit documentation of what it writes.

## Tests

28 new tests in `tests/test_domain_tools.py` using duck-typed mocks (no COM required). Key coverage:
- Truncation at `_MAX_ITEMS` for all detail-returning tools
- `result_count` equals true pre-truncation total (large mock exceeds cap)
- `get_design_summary`: failures never truncated even when fail count > 200
- Passes truncated before failures
- `pass_count`/`fail_count` always reflect true totals, not sample lengths
- Compliance assertion fields always present
- Error paths (results not available)
- Filtered queries (`member_ids`, `load_cases`, `node_ids` parameters)

All 458 tests pass (132 executor + 85 skills + 28 domain + existing suite).

---

Questions or feedback: julius.guay@bentley.com
