### PR TITLE
fix/file-import-remove-deepfreeze

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ pytest -m integration -v              # Integration tests (Windows + STAAD runni
 - `ALLOWED_BUILTINS` and `ALLOWED_MODULE_ATTRS` in `sandbox/const.py` are allowlists, not blocklists
 - `COMProxy` must block all internal COM attributes (`_oleobj_`, `_ApplyTypes_`, etc.)
 - File path validation must reject UNC paths and writes to `Windows/`, `Program Files/`, `ProgramData/`
-- Inputs passed to the sandbox must be deep-frozen (tuples, not lists) to prevent mutation
+- File inputs passed to the sandbox use fresh native lists/dicts for agent compatibility. Sandbox mutations must remain local to that execution and must never alter the source file or persist across executions.
 - HTTP mode requires `SecFetchMiddleware` and supports optional bearer token auth
 - Never expose stack traces to end users — sanitize error messages
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,14 @@ CSV and XLSX files directly and injects the data into the sandbox as the `input_
 
 | Parameter | Description |
 |-----------|-------------|
-| `input_path` | Path to a `.csv` or `.xlsx` file. The server reads and parses it, then injects the data as the immutable `input_data` variable in the sandbox. |
-| `output_path` | Path where the sandbox return value will be written. The return value must be a list-of-lists (CSV) or a `{sheet_name: {columns, rows}}` dict (multi-sheet XLSX). |
+| `input_data_path` | Path to a `.csv` or `.xlsx` file. The server reads and parses it, then injects as the `input_data` variable in the sandbox. |
+| `output_data_path` | Path where the sandbox return value will be written. The return value must be a list-of-lists (CSV) or a `{sheet_name: {columns, rows}}` dict (multi-sheet XLSX). |
 | `overwrite` | Allow overwriting an existing output file (default `false`). |
+
+`input_data` has a stable, extension-specific shape:
+
+- CSV: a list of row lists. If a header is detected, it is `input_data[0]` and data rows start at `input_data[1:]`.
+- XLSX: a dict: `{sheet_name: {"columns": list, "rows": list_of_rows}}`.
 
 **Path containment:** File paths must resolve inside a configured allowed boundary before any read/write occurs.
 The server supports both **client-configured MCP roots** and **server-configured allowed directories** (via `--allowed-dirs` or `user_config.allowed_directories` in the manifest).

--- a/src/openstaad_mcp/file_io/__init__.py
+++ b/src/openstaad_mcp/file_io/__init__.py
@@ -15,7 +15,7 @@ Sub-modules
 ``readers``     -- BaseReader, CSVReader, XLSXReader
 ``writers``     -- BaseWriter, CSVWriter, XLSXWriter
 ``models``      -- Pydantic models for return-value validation
-``validation``  -- validate_return_value, validate_args_allowed_dirs, deep_freeze
+``validation``  -- validate_return_value, validate_args_allowed_dirs
 ``helpers``     -- get_allowed_dirs, get_input_data, dispatch functions
 """
 
@@ -26,18 +26,13 @@ from openstaad_mcp.file_io.helpers import (
     write_output_file,
 )
 from openstaad_mcp.file_io.readers import CSVReader, XLSXReader
-from openstaad_mcp.file_io.validation import (
-    deep_freeze,
-    validate_args_allowed_dirs,
-    validate_return_value,
-)
+from openstaad_mcp.file_io.validation import validate_args_allowed_dirs, validate_return_value
 from openstaad_mcp.file_io.writers import CSVWriter
 
 __all__ = [
     "CSVReader",
     "CSVWriter",
     "XLSXReader",
-    "deep_freeze",
     "get_allowed_dirs",
     "get_input_data",
     "read_input_file",

--- a/src/openstaad_mcp/file_io/helpers.py
+++ b/src/openstaad_mcp/file_io/helpers.py
@@ -17,7 +17,7 @@ from fastmcp.server.context import Context
 
 from openstaad_mcp.file_io.path_validator import FileIOError, parse_roots_to_dirs, validate_io_path
 from openstaad_mcp.file_io.readers import BaseReader, CSVReader, XLSXReader
-from openstaad_mcp.file_io.validation import deep_freeze, validate_return_value
+from openstaad_mcp.file_io.validation import validate_return_value
 from openstaad_mcp.file_io.writers import BaseWriter, CSVWriter, XLSXWriter
 
 logger = logging.getLogger(__name__)
@@ -96,12 +96,11 @@ async def get_allowed_dirs(ctx: Context, args_allowed_dirs: list[Path]) -> list[
 
 
 async def get_input_data(input_path: str | None, allowed_dirs: list[Path]) -> tuple[Any, dict[str, Any] | None]:
-    """Validate path, read file, freeze data.  Returns ``(data, summary)``."""
+    """Validate and read an input file. Returns ``(data, summary)``."""
     if input_path is None:
         return None, None
     resolved_input = validate_io_path(input_path, allowed_dirs, mode="read")
-    data, input_summary = read_input_file(resolved_input)
-    return deep_freeze(data), input_summary
+    return read_input_file(resolved_input)
 
 
 async def detect_input_output_collision(

--- a/src/openstaad_mcp/file_io/models.py
+++ b/src/openstaad_mcp/file_io/models.py
@@ -86,7 +86,7 @@ def check_cell(v: Any, reject_formula: bool = True) -> CellValue:
 
 
 # ---------------------------------------------------------------------------
-# Row type — a list (or tuple) of cell values
+# Row type — a list of cell values
 # ---------------------------------------------------------------------------
 
 Row = Annotated[list[CellValue], "A row of cell values"]
@@ -99,14 +99,6 @@ Row = Annotated[list[CellValue], "A row of cell values"]
 
 class FlatOutput(RootModel[list[Row]]):
     """Flat tabular output: list of rows, each row a list of JSON-primitive cells."""
-
-    @model_validator(mode="before")
-    @classmethod
-    def _coerce_sequences(cls, v: Any) -> Any:
-        """Accept tuples (from deep_freeze) as rows."""
-        if isinstance(v, (list, tuple)):
-            return [list(row) if isinstance(row, (list, tuple)) else row for row in v]
-        return v
 
     @model_validator(mode="after")
     def _check_limits(self) -> FlatOutput:
@@ -133,19 +125,6 @@ class SheetData(BaseModel):
 
     columns: list[CellValue]
     rows: list[Row]
-
-    @model_validator(mode="before")
-    @classmethod
-    def _coerce_sequences(cls, v: Any) -> Any:
-        """Accept tuples (from deep_freeze) as columns/rows."""
-        if isinstance(v, dict):
-            data = dict(v)
-            if "columns" in data and isinstance(data["columns"], tuple):
-                data["columns"] = list(data["columns"])
-            if "rows" in data and isinstance(data["rows"], (list, tuple)):
-                data["rows"] = [list(r) if isinstance(r, (list, tuple)) else r for r in data["rows"]]
-            return data
-        return v
 
     @model_validator(mode="after")
     def _check_limits(self) -> SheetData:

--- a/src/openstaad_mcp/file_io/validation.py
+++ b/src/openstaad_mcp/file_io/validation.py
@@ -4,14 +4,13 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 See LICENSE.md in the project root for license terms and full copyright notice.
 ---------------------------------------------------------------------------------------------
 
-Validation and data-freezing utilities for file I/O.
+Validation utilities for file I/O.
 """
 
 from __future__ import annotations
 
 import os
 from pathlib import Path
-from types import MappingProxyType
 from typing import Any
 
 from pydantic import ValidationError
@@ -27,7 +26,7 @@ def validate_return_value(path: Path, value: Any) -> None:
     - ``list[list[primitive]]``  (flat / CSV / single-sheet)
     - ``dict[str, {columns: list, rows: list[list[primitive]]}]``  (multi-sheet)
 
-    Tuples are accepted interchangeably with lists (sandbox returns frozen data).
+    Pydantic accepts tuples interchangeably with lists.
     """
     ext = path.suffix.lower()
     if isinstance(value, (list, tuple)):
@@ -87,19 +86,3 @@ def validate_args_allowed_dirs(allowed_dirs: list[str] | None) -> list[Path]:
             result.append(normalized_original)
 
     return result
-
-
-def deep_freeze(data: Any) -> Any:
-    """Recursively convert mutable containers to immutable equivalents.
-
-    - ``list`` -> ``tuple``
-    - ``dict`` -> ``MappingProxyType`` (with recursively frozen values)
-    - Primitives (str, int, float, bool, None) pass through unchanged.
-    """
-    if data is None or isinstance(data, (str, int, float, bool)):
-        return data
-    if isinstance(data, (list, tuple)):
-        return tuple(deep_freeze(item) for item in data)
-    if isinstance(data, dict):
-        return MappingProxyType({k: deep_freeze(v) for k, v in data.items()})
-    return data

--- a/src/openstaad_mcp/sandbox/executor.py
+++ b/src/openstaad_mcp/sandbox/executor.py
@@ -94,7 +94,7 @@ class Executor:
         staad_object:
             The connected OpenSTAAD root object (or a mock for testing).
         input_data:
-            Optional pre-parsed, deep-frozen data injected as ``input_data``
+            Optional pre-parsed data injected as ``input_data``
             in the sandbox globals.  ``None`` when no input file is provided.
 
         Returns

--- a/src/openstaad_mcp/sandbox/executor.py
+++ b/src/openstaad_mcp/sandbox/executor.py
@@ -21,6 +21,7 @@ import json
 import sys
 import threading
 import time
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 
@@ -116,7 +117,7 @@ class Executor:
         sandbox_globals: dict[str, Any] = {"__builtins__": self.safe_builtins.copy()}
         sandbox_globals.update(self.injected_modules)
         sandbox_globals["staad"] = COMProxy(staad_object)
-        sandbox_globals["input_data"] = input_data
+        sandbox_globals["input_data"] = deepcopy(input_data)
 
         # ── 4. Execute with stdout/stderr capture ───────────────────
         captured_out, captured_err = LimitedStringIO(), LimitedStringIO()

--- a/src/openstaad_mcp/server.py
+++ b/src/openstaad_mcp/server.py
@@ -225,8 +225,19 @@ def _register_tools(
         instance: str
             Alias (from ``list_instances``, e.g. ``staadPro1``) of the STAAD instance to target. If omitted, last opened instance is selected.
         input_data_path: str, optional
-            Path on user LOCAL filesystem to a ``.csv`` or ``.xlsx`` file. Its content is injected as the immutable `input_data` variable inside the sandbox.
+            Path on user LOCAL filesystem to a ``.csv`` or ``.xlsx`` file. Its content is parsed and injected as ``input_data`` inside the sandbox.
             Use this to feed large datasets (e.g. node loads, section properties) into your code without hardcoding them.
+            The shape is determined by the extension:
+            - CSV -> list of row lists. When a header is detected, it is the first row:
+                columns = input_data[0]
+                for row in input_data[1:]:
+                    print(row)
+            - XLSX -> dict mapping every sheet to ``columns`` and ``rows`` lists:
+                sheet = input_data["Sheet1"]
+                columns = sheet["columns"]
+                for row in sheet["rows"]:
+                    print(row)
+            The containers are mutable for normal Python compatibility, but are fresh for each execution; mutations do not change the source file or persist across executions.
         output_data_path: str, optional
             Path on user LOCAL filesystem to a ``.csv`` or ``.xlsx`` file where to write the ``result`` value.
             Use this to avoid flooding the context window with large amount of data. The ``result`` variable must be formatted as one of:

--- a/src/openstaad_mcp/staad_skills/staad-core/SKILL.md
+++ b/src/openstaad_mcp/staad_skills/staad-core/SKILL.md
@@ -12,7 +12,7 @@ description: "ALWAYS load first for any STAAD.Pro automation. Covers: Python san
 - Pre-injected names (do NOT import): `staad`, `input_data`, `json`, `math`
 - `import` statements, `dir()`, `getattr()`, ... are **BLOCKED** — use skills for discovery, only use pre-injected names in code
 - `staad` is already connected and ready — do NOT call any initialization function
-- `input_data` is injected if `input_data_path` is provided in `execute_code` params — use it to feed large datasets into the sandbox without hardcoding
+- `input_data` is injected if `input_data_path` is provided in `execute_code` params — use it to feed large datasets into the sandbox without hardcoding. CSV input is a list of row lists (the detected header is row 0); XLSX input is a `{sheet_name: {"columns": list, "rows": list_of_rows}}` dict.
 - Sub-modules: `geo = staad.Geometry`, `prop = staad.Property`, `sup = staad.Support`, `load = staad.Load`, `cmd = staad.Command`, `out = staad.Output`, `design = staad.Design`
 - If `output_data_path` is provided, write the `result` variable to that file path instead of returning it in the context (use for large/tabular data). The `execute_code` return value will contain a summary of the `result` content instead (e.g. number of rows, columns and a sample of rows).
 - Both `input_data_path` and `output_data_path` must be on the user LOCAL filesystem and inside MCP roots or configured `allowed_dirs`. On Claude Desktop, users can configure allowed directories in the extension settings and Claude can use the filesystem `copy_file_to_claude` tool to move files to Claude's filesystem.
@@ -152,7 +152,7 @@ staad.CloseSTAADFile()
 ## Gotchas
 
 - `import`, `dir()`, `getattr()`, ... are blocked — only `staad`, `input_data`, `json`, `math` are available
-- If `input_data_path` is provided, `input_data` is injected as an immutable variable — use it to feed large datasets into the sandbox without hardcoding
+- If `input_data_path` is provided, `input_data` is injected as fresh lists/dicts — use it to feed large datasets into the sandbox without hardcoding
 - If `output_data_path` is provided, write the `result` variable to that file path instead of returning it in the context (use for large/tabular data). The `execute_code` return value will contain a summary of the `result` content instead (e.g. number of rows, columns and a sample of rows).
 - Both `input_data_path` and `output_data_path` must be on the user LOCAL filesystem and inside MCP roots or configured `allowed_dirs`. On Claude Desktop, users can configure allowed directories in the extension settings and Claude can use the filesystem `copy_file_to_claude` tool to move files to Claude's filesystem.
 - Use `staad.GetSTAADFile()` to get the current model path after a file switch

--- a/tests/file_io/test_readers.py
+++ b/tests/file_io/test_readers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from openstaad_mcp.file_io import CSVReader, XLSXReader, read_input_file
+from openstaad_mcp.file_io import CSVReader, XLSXReader, get_input_data, read_input_file
 from openstaad_mcp.file_io.path_validator import FileIOError
 from openstaad_mcp.file_io.readers import _detect_header
 
@@ -288,6 +288,34 @@ class TestSummaries:
         summary = XLSXReader(FIXTURES_DIR / "multi_sheet.xlsx").build_summary(data)
         assert set(summary["sheets"]) == {"Beams", "Loads"}
         assert summary["total_rows"] == 1
+
+
+class TestInputData:
+    async def test_csv_returns_fresh_mutable_native_containers(self):
+        data, _ = await get_input_data(str(FIXTURES_DIR / "basic.csv"), [FIXTURES_DIR])
+
+        assert isinstance(data, list)
+        assert isinstance(data[0], list)
+        data[1][0] = "changed"
+        data.append(["new", 3])
+
+        reread, _ = await get_input_data(str(FIXTURES_DIR / "basic.csv"), [FIXTURES_DIR])
+        assert reread == [["name", "value"], ["A", 1], ["B", 2.5]]
+
+    async def test_xlsx_returns_fresh_mutable_native_containers(self):
+        data, _ = await get_input_data(str(FIXTURES_DIR / "single_sheet.xlsx"), [FIXTURES_DIR])
+
+        assert isinstance(data, dict)
+        assert isinstance(data["Sheet1"], dict)
+        assert isinstance(data["Sheet1"]["columns"], list)
+        assert isinstance(data["Sheet1"]["rows"], list)
+        assert isinstance(data["Sheet1"]["rows"][0], list)
+        data["Sheet1"]["columns"][0] = "changed"
+        data["Sheet1"]["rows"].append([5, 6])
+        data["Other"] = {"columns": [], "rows": []}
+
+        reread, _ = await get_input_data(str(FIXTURES_DIR / "single_sheet.xlsx"), [FIXTURES_DIR])
+        assert reread == {"Sheet1": {"columns": ["a", "b"], "rows": [[1, 2], [3, 4]]}}
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/file_io/test_validation.py
+++ b/tests/file_io/test_validation.py
@@ -1,12 +1,11 @@
-"""Tests for return-value validation (Pydantic models), deep freeze, and allowed dirs."""
+"""Tests for return-value validation and allowed directories."""
 
 import os
 from pathlib import Path
-from types import MappingProxyType
 
 import pytest
 
-from openstaad_mcp.file_io import deep_freeze, validate_args_allowed_dirs, validate_return_value
+from openstaad_mcp.file_io import validate_args_allowed_dirs, validate_return_value
 from openstaad_mcp.file_io.path_validator import FileIOError
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -75,7 +74,7 @@ class TestValidateReturnValue:
         assert exc_info.value.code == "INVALID_RETURN_SHAPE"
 
     def test_accepts_tuples_as_rows(self):
-        """Tuples (from deep_freeze) should be accepted as rows."""
+        """Tuples should be accepted as rows."""
         validate_return_value(Path("test.csv"), (("a", "b"), (1, 2)))
 
     @pytest.mark.parametrize("cell", ["=SUM(A1)", "+cmd|'/C calc'!A0", "-2+3", "@SUM(1,2)"])
@@ -190,48 +189,13 @@ class TestValidateReturnValue:
         assert exc_info.value.code == "INVALID_RETURN_SHAPE"
 
     def test_accepts_tuples_in_multi_sheet(self):
-        """Frozen multi-sheet data should be accepted."""
+        """Tuple-based multi-sheet data should be accepted."""
         validate_return_value(
             Path("test.xlsx"),
             {
                 "S1": {"columns": ("a",), "rows": ((1,),)},
             },
         )
-
-
-# ═══════════════════════════════════════════════════════════════════════════
-# Deep freeze
-# ═══════════════════════════════════════════════════════════════════════════
-
-
-class TestDeepFreeze:
-    def test_lists_become_tuples(self):
-        data = [[1, 2], [3, 4]]
-        frozen = deep_freeze(data)
-        assert isinstance(frozen, tuple)
-        assert isinstance(frozen[0], tuple)
-
-    def test_dict_values_frozen(self):
-        data = {"S": {"columns": ["a"], "rows": [[1]]}}
-        frozen = deep_freeze(data)
-        assert isinstance(frozen, MappingProxyType)
-        assert isinstance(frozen["S"], MappingProxyType)
-        assert isinstance(frozen["S"]["rows"], tuple)
-
-    def test_dict_is_immutable(self):
-        frozen = deep_freeze({"a": 1})
-        with pytest.raises(TypeError):
-            frozen["a"] = 2
-        with pytest.raises(TypeError):
-            frozen["b"] = 3
-
-    def test_none_passthrough(self):
-        assert deep_freeze(None) is None
-
-    def test_primitives_unchanged(self):
-        assert deep_freeze(42) == 42
-        assert deep_freeze("hello") == "hello"
-        assert deep_freeze(True) is True
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/sandbox/test_executor.py
+++ b/tests/sandbox/test_executor.py
@@ -682,25 +682,6 @@ class TestInputInjection:
         assert r.success
         assert r.result == [["a", "b"], [1, 2], [3, 4]]
 
-    def test_input_deeply_immutable(self, staad, executor):
-        """Sandbox code cannot mutate ``input_data`` (tuples are immutable)."""
-        data = (("a", "b"), (1, 2))
-        r = executor.execute(
-            dedent(
-                """
-                try:
-                    input_data[0] = "mutated"
-                    result = "mutation succeeded"
-                except TypeError:
-                    result = "immutable"
-                """
-            ),
-            staad,
-            input_data=data,
-        )
-        assert r.success
-        assert r.result == "immutable"
-
     def test_input_iterable(self, staad, executor):
         """Sandbox code can iterate over ``input_data``."""
         data = ((10,), (20,), (30,))
@@ -728,11 +709,11 @@ class TestInputInjection:
 
     def test_input_dict_shape(self, staad, executor):
         """Dict-shaped input_data (XLSX multi-sheet) works."""
-        data = {"Sheet1": {"columns": ("a",), "rows": ((1,), (2,))}}
+        data = {"Sheet1": {"columns": ["a"], "rows": [[1], [2]]}}
         r = executor.execute(
-            "result = len(input_data['Sheet1']['rows'])",
+            "input_data['Sheet1']['rows'].append([3])\nresult = [isinstance(input_data, dict), input_data]",
             staad,
             input_data=data,
         )
         assert r.success
-        assert r.result == 2
+        assert r.result == [True, {"Sheet1": {"columns": ["a"], "rows": [[1], [2], [3]]}}]


### PR DESCRIPTION
File ingestion exposed immutable tuples and `MappingProxyType` objects. This confused AI agents expecting standard Python `list` and `dict` values, often causing overly defensive or incompatible generated code.

This PR proposes to:
- inject CSV data as native `list[list]`.
- inject XLSX data as native nested `dict`/`list` structures.
- remove `deep_freeze`, `MappingProxyType`, and the `isinstance` compatibility shim.
- document exact input shapes and mutability guarantees.
- add CSV/XLSX tests proving mutations remain local and do not affect source files or subsequent executions.
