### PR TITLE
fix/parse_roots_to_dirs

### DIFF
--- a/src/openstaad_mcp/file_io/path_validator.py
+++ b/src/openstaad_mcp/file_io/path_validator.py
@@ -49,7 +49,7 @@ def parse_roots_to_dirs(roots: list) -> list[Path]:
     dirs: list[Path] = []
     for root in roots:
         uri: str = root.uri if hasattr(root, "uri") else str(root)
-        parsed = urlparse(uri)
+        parsed = urlparse(str(uri))
         if parsed.scheme != "file":
             continue
         # RFC 8089: file:///C:/path → parsed.path = "/C:/path"

--- a/src/openstaad_mcp/file_io/path_validator.py
+++ b/src/openstaad_mcp/file_io/path_validator.py
@@ -49,7 +49,7 @@ def parse_roots_to_dirs(roots: list) -> list[Path]:
     dirs: list[Path] = []
     for root in roots:
         uri: str = root.uri if hasattr(root, "uri") else str(root)
-        parsed = urlparse(str(uri))
+        parsed = urlparse(str(uri))  # str() normalises Pydantic FileUrl / AnyUrl types
         if parsed.scheme != "file":
             continue
         # RFC 8089: file:///C:/path → parsed.path = "/C:/path"

--- a/tests/file_io/test_path_validator.py
+++ b/tests/file_io/test_path_validator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from openstaad_mcp.file_io.path_validator import FileIOError, validate_io_path
+from openstaad_mcp.file_io.path_validator import FileIOError, parse_roots_to_dirs, validate_io_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -211,3 +211,107 @@ class TestFileIOError:
         assert err.code == "TEST_CODE"
         assert err.message == "some detail"
         assert "TEST_CODE" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# parse_roots_to_dirs
+# ---------------------------------------------------------------------------
+
+
+class _RootWithStrUri:
+    """Minimal MCP Root stub whose .uri is a plain Python str."""
+
+    def __init__(self, uri: str) -> None:
+        self.uri = uri
+
+
+class _FileUrlLike:
+    """Mimics a Pydantic FileUrl / AnyUrl object: has __str__ but NO .decode().
+
+    This is the shape returned by newer versions of the ``mcp`` Python library
+    when a Claude Code client sends workspace roots.  The bug was that
+    ``urlparse`` received this object directly and tried to call ``.decode()``
+    on it (bytes branch), raising AttributeError.
+    """
+
+    def __init__(self, uri: str) -> None:
+        self._uri = uri
+
+    def __str__(self) -> str:
+        return self._uri
+
+    # Deliberately NO .decode() — that's the point of this test fixture.
+
+
+class _RootWithFileUrlUri:
+    """MCP Root whose .uri is a FileUrl-like object (not a plain str)."""
+
+    def __init__(self, uri: str) -> None:
+        self.uri = _FileUrlLike(uri)
+
+
+class TestParseRootsToDirs:
+    """parse_roots_to_dirs must handle every URI shape a real MCP client can send."""
+
+    def test_empty_list_returns_empty(self):
+        assert parse_roots_to_dirs([]) == []
+
+    def test_plain_str_uri_posix(self):
+        root = _RootWithStrUri("file:///home/user/models")
+        result = parse_roots_to_dirs([root])
+        assert result == [Path("/home/user/models")]
+
+    def test_plain_str_uri_windows(self):
+        """RFC 8089 Windows path: file:///C:/Users/... → C:/Users/..."""
+        root = _RootWithStrUri("file:///C:/Users/user/models")
+        result = parse_roots_to_dirs([root])
+        assert len(result) == 1
+        assert str(result[0]).startswith("C:")
+
+    def test_fileurl_object_uri_does_not_raise(self, tmp_path: Path):
+        """Regression: FileUrl objects must not trigger AttributeError from urlparse.
+
+        Older code passed root.uri directly to urlparse().  urlparse treats any
+        non-str input as bytes and calls .decode() on it — FileUrl has no
+        .decode(), so it raised AttributeError.  The fix is str(uri) before
+        urlparse.  This test would fail against the unfixed implementation.
+        """
+        root = _RootWithFileUrlUri(f"file:///{tmp_path.as_posix()}")
+        # Must not raise — this was the bug triggered by Claude Code clients.
+        result = parse_roots_to_dirs([root])
+        assert len(result) == 1
+
+    def test_fileurl_object_uri_resolves_correctly(self, tmp_path: Path):
+        """FileUrl-typed URI must produce the same Path as a plain-str URI."""
+        uri = f"file:///{tmp_path.as_posix()}"
+        plain = parse_roots_to_dirs([_RootWithStrUri(uri)])
+        typed = parse_roots_to_dirs([_RootWithFileUrlUri(uri)])
+        assert plain == typed
+
+    def test_non_file_scheme_skipped(self):
+        root = _RootWithStrUri("https://example.com/models")
+        assert parse_roots_to_dirs([root]) == []
+
+    def test_mixed_schemes_only_file_included(self, tmp_path: Path):
+        roots = [
+            _RootWithStrUri("https://example.com/ignored"),
+            _RootWithStrUri(f"file:///{tmp_path.as_posix()}"),
+        ]
+        result = parse_roots_to_dirs(roots)
+        assert len(result) == 1
+
+    def test_root_without_uri_attribute_uses_str(self, tmp_path: Path):
+        """Roots that have no .uri fall back to str(root)."""
+
+        class _BareRoot:
+            def __str__(self) -> str:
+                return f"file:///{tmp_path.as_posix()}"
+
+        result = parse_roots_to_dirs([_BareRoot()])
+        assert len(result) == 1
+
+    def test_percent_encoded_path_decoded(self):
+        """Spaces and special chars in paths must be unquoted."""
+        root = _RootWithStrUri("file:///home/user/my%20models")
+        result = parse_roots_to_dirs([root])
+        assert "my models" in str(result[0])


### PR DESCRIPTION
**Problem**

execute_code raised 'FileUrl' object has no attribute 'decode' for any Claude Code client, making the tool completely unusable.

Root cause: parse_roots_to_dirs passed root.uri directly to Python's urlparse(). When a client correctly implements the MCP Roots protocol (as Claude Code does), newer versions of the mcp library return Root objects whose .uri is a Pydantic AnyUrl/FileUrl typed object — not a plain str. urlparse handles only str and bytes; for anything else it enters the bytes branch and calls .decode(), which Pydantic URL types don't have.

Clients that don't implement MCP Roots (e.g. Copilot, Codex) were unaffected: list_roots() either failed or returned an empty list, so parse_roots_to_dirs was never called with real data.

**Fix**

One-line change in parse_roots_to_dirs (path_validator.py): normalize the URI to a plain str with str(uri) before passing it to urlparse. This is safe for all input shapes — plain strings, Pydantic URL types, and any future typed wrappers.
```
# before
uri: str = root.uri if hasattr(root, "uri") else str(root)
parsed = urlparse(uri)

# after
uri: str = root.uri if hasattr(root, "uri") else str(root)
parsed = urlparse(str(uri))   # str() normalises Pydantic FileUrl / AnyUrl types
```
**Tests**

Added TestParseRootsToDirs (9 tests) to tests/file_io/test_path_validator.py:

- Regression test (test_fileurl_object_uri_does_not_raise): uses a _FileUrlLike stub that intentionally has no .decode() method — would fail against the pre-fix code.
- Correctness test (test_fileurl_object_uri_resolves_correctly): same URI via FileUrl vs plain str must produce identical Path results.
- Posix and Windows RFC 8089 paths, https:// scheme skipping, percent-encoded paths, roots without .uri attribute.

---